### PR TITLE
DEBT: Refactored comprehensive benchmark tests

### DIFF
--- a/CHANGELOG/CHANGELOG-1.x.md
+++ b/CHANGELOG/CHANGELOG-1.x.md
@@ -16,6 +16,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ---
+## [1.7.1] - 2024-OCT-30
+
+### Added
+### Changed
+- **DEBT:** Refactored Comprehensive Benchmark Tests 
+  - Added a suite of benchmark tests (`nanoid_bench_test.go`) within the `nanoid` package. 
+  - Benchmarks cover both serial and concurrent generation of Nano IDs. 
+  - Included tests for:
+    - Default ID generation using `Generate()` and `GenerateSize()`. 
+    - Various ID sizes: 8, 16, 21, 32, 64, 128 characters. 
+    - Custom alphabets with varying lengths: 2, 16, 32, 64, 95 characters. 
+    - Generation of IDs using custom alphabets both serially and in parallel. 
+    - Performance measurement of creating new generator instances.
+    - The `makeAlphabet` helper function to generate alphabets using only single-byte, printable ASCII characters.
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+---
 ## [1.7.0] - 2024-OCT-30
 
 ### Added
@@ -109,7 +129,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/scriptures-social/platform/compare/v1.7.0...HEAD
+[Unreleased]: https://github.com/scriptures-social/platform/compare/v1.7.1...HEAD
+[1.7.1]: https://github.com/sixafter/nanoid/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/sixafter/nanoid/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/sixafter/nanoid/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/sixafter/nanoid/compare/v1.4.0...v1.5.0

--- a/README.md
+++ b/README.md
@@ -226,34 +226,42 @@ make bench
 Sample output might look like this:
 
 ```shell
-go test -bench=. -benchmem ./...
+go test -bench=. -benchmem -memprofile=mem.out -cpuprofile=cpu.out
 goos: darwin
 goarch: arm64
 pkg: github.com/sixafter/nanoid
 cpu: Apple M2 Ultra
-BenchmarkGenerateDefault-24                      4321281               271.5 ns/op            48 B/op          2 allocs/op
-BenchmarkGenerateCustomAlphabet-24               4229205               289.5 ns/op            32 B/op          2 allocs/op
-BenchmarkGenerateShortID-24                      4262588               266.8 ns/op            10 B/op          2 allocs/op
-BenchmarkGenerateLongID-24                       2919226               405.6 ns/op           128 B/op          2 allocs/op
-BenchmarkGenerateMaxAlphabet-24                  4623288               262.4 ns/op            32 B/op          2 allocs/op
-BenchmarkGenerateMinAlphabet-24                  4676742               260.2 ns/op            32 B/op          2 allocs/op
-BenchmarkGenerateWithBufferPool-24               4219680               283.5 ns/op            32 B/op          2 allocs/op
-BenchmarkGenerateDefaultParallel-24              1701912               692.5 ns/op            48 B/op          2 allocs/op
-BenchmarkGenerateCustomAlphabetParallel-24       1688263               707.9 ns/op            32 B/op          2 allocs/op
-BenchmarkGenerateShortIDParallel-24              1773108               693.1 ns/op            10 B/op          2 allocs/op
-BenchmarkGenerateLongIDParallel-24               1298353               930.2 ns/op           128 B/op          2 allocs/op
-BenchmarkGenerateExtremeConcurrency-24           1710836               700.4 ns/op            48 B/op          2 allocs/op
-BenchmarkGenerateDifferentLengths/Length_5-24    4483588               269.6 ns/op            10 B/op          2 allocs/op
-BenchmarkGenerateDifferentLengths/Length_10-24           4140530               285.4 ns/op            32 B/op          2 allocs/op
-BenchmarkGenerateDifferentLengths/Length_20-24           3674721               324.3 ns/op            48 B/op          2 allocs/op
-BenchmarkGenerateDifferentLengths/Length_50-24           2838957               427.9 ns/op           128 B/op          2 allocs/op
-BenchmarkGenerateDifferentLengths/Length_100-24          1602020               802.2 ns/op           224 B/op          2 allocs/op
-BenchmarkGenerateDifferentAlphabets/Alphabet_2-24        4195101               270.4 ns/op            32 B/op          2 allocs/op
-BenchmarkGenerateDifferentAlphabets/Alphabet_6-24        3959139               293.4 ns/op            32 B/op          2 allocs/op
-BenchmarkGenerateDifferentAlphabets/Alphabet_26-24       4257424               292.6 ns/op            32 B/op          2 allocs/op
-BenchmarkGenerateDifferentAlphabets/Alphabet_38-24       3815774               318.1 ns/op            32 B/op          2 allocs/op
+BenchmarkDefaultGenerate-24                      4362076               274.2 ns/op            48 B/op          2 allocs/op
+BenchmarkDefaultGenerateSize/Size8-24            4553710               258.6 ns/op            16 B/op          2 allocs/op
+BenchmarkDefaultGenerateSize/Size16-24           4399778               274.1 ns/op            32 B/op          2 allocs/op
+BenchmarkDefaultGenerateSize/Size21-24           4256088               285.9 ns/op            48 B/op          2 allocs/op
+BenchmarkDefaultGenerateSize/Size32-24           4204159               284.3 ns/op            64 B/op          2 allocs/op
+BenchmarkDefaultGenerateSize/Size64-24           3791118               322.7 ns/op           128 B/op          2 allocs/op
+BenchmarkDefaultGenerateSize/Size128-24          3157098               377.9 ns/op           256 B/op          2 allocs/op
+BenchmarkDefaultGenerateParallel-24              1516693               828.8 ns/op            48 B/op          2 allocs/op
+BenchmarkDefaultGenerateSizeParallel/Size8-24            1560518               786.8 ns/op            16 B/op          2 allocs/op
+BenchmarkDefaultGenerateSizeParallel/Size16-24           1364043               860.7 ns/op            32 B/op          2 allocs/op
+BenchmarkDefaultGenerateSizeParallel/Size21-24           1499124               786.4 ns/op            48 B/op          2 allocs/op
+BenchmarkDefaultGenerateSizeParallel/Size32-24           1490713               814.6 ns/op            64 B/op          2 allocs/op
+BenchmarkDefaultGenerateSizeParallel/Size64-24           1375413               861.1 ns/op           128 B/op          2 allocs/op
+BenchmarkDefaultGenerateSizeParallel/Size128-24          1220480               990.9 ns/op           256 B/op          2 allocs/op
+BenchmarkGeneratorGenerate-24                            4365238               276.7 ns/op            48 B/op          2 allocs/op
+BenchmarkGeneratorGenerateParallel-24                    1507068               799.6 ns/op            48 B/op          2 allocs/op
+BenchmarkCustomAlphabet-24                               4211919               285.5 ns/op            48 B/op          2 allocs/op
+BenchmarkCustomAlphabetParallel-24                       1513590               803.8 ns/op            48 B/op          2 allocs/op
+BenchmarkNewGenerator-24                                 6683338               177.0 ns/op           176 B/op          3 allocs/op
+BenchmarkCustomAlphabetLengths/AlphabetLength2-24        4331044               276.9 ns/op            48 B/op          2 allocs/op
+BenchmarkCustomAlphabetLengths/AlphabetLength16-24       4350872               285.4 ns/op            48 B/op          2 allocs/op
+BenchmarkCustomAlphabetLengths/AlphabetLength32-24       4273230               287.2 ns/op            48 B/op          2 allocs/op
+BenchmarkCustomAlphabetLengths/AlphabetLength64-24       3908989               291.1 ns/op            48 B/op          2 allocs/op
+BenchmarkCustomAlphabetLengths/AlphabetLength95-24       3480422               346.8 ns/op            48 B/op          2 allocs/op
+BenchmarkCustomAlphabetLengthsParallel/AlphabetLength2-24                1496703               804.5 ns/op            48 B/op          2 allocs/op
+BenchmarkCustomAlphabetLengthsParallel/AlphabetLength16-24               1511534               848.3 ns/op            48 B/op          2 allocs/op
+BenchmarkCustomAlphabetLengthsParallel/AlphabetLength32-24               1507296               799.4 ns/op            48 B/op          2 allocs/op
+BenchmarkCustomAlphabetLengthsParallel/AlphabetLength64-24               1520260               800.6 ns/op            48 B/op          2 allocs/op
+BenchmarkCustomAlphabetLengthsParallel/AlphabetLength95-24               1337623               885.6 ns/op            48 B/op          2 allocs/op
 PASS
-ok      github.com/sixafter/nanoid      34.564s
+ok      github.com/sixafter/nanoid      51.470s
 ```
 
 * `ns/op` (Nanoseconds per Operation):

--- a/nanoid_benchmark_test.go
+++ b/nanoid_benchmark_test.go
@@ -6,287 +6,198 @@
 package nanoid
 
 import (
-	"strconv"
+	"fmt"
 	"testing"
 )
 
-// BenchmarkGenerateDefault benchmarks the default generator with default alphabet and ID length.
-func BenchmarkGenerateDefault(b *testing.B) {
+func BenchmarkDefaultGenerate(b *testing.B) {
 	b.ReportAllocs()
-	gen, err := New(DefaultAlphabet, nil)
-	if err != nil {
-		b.Fatalf("Failed to create generator: %v", err)
-	}
-
-	idLength := DefaultSize // Default Nano ID length
 	for i := 0; i < b.N; i++ {
-		_, err := gen.Generate(idLength)
+		_, err := Generate()
 		if err != nil {
-			b.Fatalf("GenerateSize failed: %v", err)
+			b.Fatal(err)
 		}
 	}
 }
 
-// BenchmarkGenerateCustomAlphabet benchmarks a custom alphabet generator with ID length 10.
-func BenchmarkGenerateCustomAlphabet(b *testing.B) {
-	b.ReportAllocs()
-	alphabet := "ABCDEF"
-	gen, err := New(alphabet, nil)
-	if err != nil {
-		b.Fatalf("Failed to create generator: %v", err)
-	}
-
-	idLength := 10
-	for i := 0; i < b.N; i++ {
-		_, err := gen.Generate(idLength)
-		if err != nil {
-			b.Fatalf("GenerateSize failed: %v", err)
-		}
-	}
-}
-
-// BenchmarkGenerateShortID benchmarks the generator with a short ID length.
-func BenchmarkGenerateShortID(b *testing.B) {
-	b.ReportAllocs()
-	gen, err := New("abcdef", nil)
-	if err != nil {
-		b.Fatalf("Failed to create generator: %v", err)
-	}
-
-	idLength := 5
-	for i := 0; i < b.N; i++ {
-		_, err := gen.Generate(idLength)
-		if err != nil {
-			b.Fatalf("GenerateSize failed: %v", err)
-		}
-	}
-}
-
-// BenchmarkGenerateLongID benchmarks the generator with a long ID length.
-func BenchmarkGenerateLongID(b *testing.B) {
-	b.ReportAllocs()
-	gen, err := New("abcdef", nil)
-	if err != nil {
-		b.Fatalf("Failed to create generator: %v", err)
-	}
-
-	idLength := 50
-	for i := 0; i < b.N; i++ {
-		_, err := gen.Generate(idLength)
-		if err != nil {
-			b.Fatalf("GenerateSize failed: %v", err)
-		}
-	}
-}
-
-// BenchmarkGenerateMaxAlphabet benchmarks the generator with the maximum allowed alphabet size (256 characters).
-func BenchmarkGenerateMaxAlphabet(b *testing.B) {
-	b.ReportAllocs()
-	// Create an alphabet of 256 unique characters
-	alphabet := make([]byte, 256)
-	for i := 0; i < 256; i++ {
-		alphabet[i] = byte(i)
-	}
-	gen, err := New(string(alphabet), nil)
-	if err != nil {
-		b.Fatalf("Failed to create generator: %v", err)
-	}
-
-	idLength := 10
-	for i := 0; i < b.N; i++ {
-		_, err := gen.Generate(idLength)
-		if err != nil {
-			b.Fatalf("GenerateSize failed: %v", err)
-		}
-	}
-}
-
-// BenchmarkGenerateMinAlphabet benchmarks the generator with the minimum allowed alphabet size (2 characters).
-func BenchmarkGenerateMinAlphabet(b *testing.B) {
-	b.ReportAllocs()
-	alphabet := "AB"
-	gen, err := New(alphabet, nil)
-	if err != nil {
-		b.Fatalf("Failed to create generator: %v", err)
-	}
-
-	idLength := 10
-	for i := 0; i < b.N; i++ {
-		_, err := gen.Generate(idLength)
-		if err != nil {
-			b.Fatalf("GenerateSize failed: %v", err)
-		}
-	}
-}
-
-// BenchmarkGenerateWithBufferPool benchmarks the generator with buffer pooling enabled.
-func BenchmarkGenerateWithBufferPool(b *testing.B) {
-	b.ReportAllocs()
-	gen, err := New("abcdef", nil)
-	if err != nil {
-		b.Fatalf("Failed to create generator: %v", err)
-	}
-
-	idLength := 10
-	for i := 0; i < b.N; i++ {
-		_, err := gen.Generate(idLength)
-		if err != nil {
-			b.Fatalf("GenerateSize failed: %v", err)
-		}
-	}
-}
-
-// BenchmarkGenerateDefaultParallel benchmarks the default generator in a parallel/concurrent setting.
-func BenchmarkGenerateDefaultParallel(b *testing.B) {
-	gen, err := New(DefaultAlphabet, nil)
-	if err != nil {
-		b.Fatalf("Failed to create generator: %v", err)
-	}
-
-	idLength := DefaultSize // Default Nano ID length
-
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			_, err := gen.Generate(idLength)
-			if err != nil {
-				b.Fatalf("GenerateSize failed: %v", err)
-			}
-		}
-	})
-}
-
-// BenchmarkGenerateCustomAlphabetParallel benchmarks a custom alphabet generator in parallel.
-func BenchmarkGenerateCustomAlphabetParallel(b *testing.B) {
-	gen, err := New("ABCDEF", nil)
-	if err != nil {
-		b.Fatalf("Failed to create generator: %v", err)
-	}
-
-	idLength := 10
-
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			_, err := gen.Generate(idLength)
-			if err != nil {
-				b.Fatalf("GenerateSize failed: %v", err)
-			}
-		}
-	})
-}
-
-// BenchmarkGenerateShortIDParallel benchmarks the generator with short IDs in parallel.
-func BenchmarkGenerateShortIDParallel(b *testing.B) {
-	gen, err := New("abcdef", nil)
-	if err != nil {
-		b.Fatalf("Failed to create generator: %v", err)
-	}
-
-	idLength := 5
-
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			_, err := gen.Generate(idLength)
-			if err != nil {
-				b.Fatalf("GenerateSize failed: %v", err)
-			}
-		}
-	})
-}
-
-// BenchmarkGenerateLongIDParallel benchmarks the generator with long IDs in parallel.
-func BenchmarkGenerateLongIDParallel(b *testing.B) {
-	gen, err := New("abcdef", nil)
-	if err != nil {
-		b.Fatalf("Failed to create generator: %v", err)
-	}
-
-	idLength := 50
-
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			_, err := gen.Generate(idLength)
-			if err != nil {
-				b.Fatalf("GenerateSize failed: %v", err)
-			}
-		}
-	})
-}
-
-// BenchmarkGenerateExtremeConcurrency benchmarks the generator under extreme concurrency.
-func BenchmarkGenerateExtremeConcurrency(b *testing.B) {
-	gen, err := New(DefaultAlphabet, nil)
-	if err != nil {
-		b.Fatalf("Failed to create generator: %v", err)
-	}
-
-	idLength := 21 // Default Nano ID length
-
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			_, err := gen.Generate(idLength)
-			if err != nil {
-				b.Fatalf("GenerateSize failed: %v", err)
-			}
-		}
-	})
-}
-
-// BenchmarkGenerateDifferentLengths benchmarks the generator with varying ID lengths.
-func BenchmarkGenerateDifferentLengths(b *testing.B) {
-	alphabet := "abcdef"
-	lengths := []int{5, 10, 20, 50, 100}
-
-	for _, length := range lengths {
-		// Correctly format the benchmark name
-		name := "Length_" + strconv.Itoa(length)
-		b.Run(name, func(b *testing.B) {
+func BenchmarkDefaultGenerateSize(b *testing.B) {
+	lengths := []int{8, 16, 21, 32, 64, 128}
+	for _, size := range lengths {
+		b.Run(fmt.Sprintf("Size%d", size), func(b *testing.B) {
 			b.ReportAllocs()
-			gen, err := New(alphabet, nil)
-			if err != nil {
-				b.Fatalf("Failed to create generator: %v", err)
-			}
-
 			for i := 0; i < b.N; i++ {
-				_, err := gen.Generate(length)
+				_, err := GenerateSize(size)
 				if err != nil {
-					b.Fatalf("GenerateSize failed: %v", err)
+					b.Fatal(err)
 				}
 			}
 		})
 	}
 }
 
-// BenchmarkGenerateDifferentAlphabets benchmarks the generator with different alphabet sizes.
-func BenchmarkGenerateDifferentAlphabets(b *testing.B) {
-	alphabets := []string{
-		"AB",                                     // 2 characters
-		"ABCDEF",                                 // 6 characters
-		"abcdefghijklmnopqrstuvwxyz",             // 26 characters
-		"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-", // 64 characters
-	}
-
-	idLength := 10
-	for _, alphabet := range alphabets {
-		// Correctly format the benchmark name
-		name := "Alphabet_" + strconv.Itoa(len(alphabet))
-		b.Run(name, func(b *testing.B) {
-			b.ReportAllocs()
-			gen, err := New(alphabet, nil)
+func BenchmarkDefaultGenerateParallel(b *testing.B) {
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, err := Generate()
 			if err != nil {
-				b.Fatalf("Failed to create generator: %v", err)
+				b.Fatal(err)
 			}
+		}
+	})
+}
 
+func BenchmarkDefaultGenerateSizeParallel(b *testing.B) {
+	lengths := []int{8, 16, 21, 32, 64, 128}
+	for _, size := range lengths {
+		b.Run(fmt.Sprintf("Size%d", size), func(b *testing.B) {
+			b.ReportAllocs()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					_, err := GenerateSize(size)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkGeneratorGenerate(b *testing.B) {
+	g, err := New(DefaultAlphabet, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := g.Generate(DefaultSize)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkGeneratorGenerateParallel(b *testing.B) {
+	g, err := New(DefaultAlphabet, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, err := g.Generate(DefaultSize)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkCustomAlphabet(b *testing.B) {
+	alphabet := "0123456789abcdef"
+	g, err := New(alphabet, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := g.Generate(DefaultSize)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkCustomAlphabetParallel(b *testing.B) {
+	alphabet := "0123456789abcdef"
+	g, err := New(alphabet, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, err := g.Generate(DefaultSize)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkNewGenerator(b *testing.B) {
+	alphabet := DefaultAlphabet
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := New(alphabet, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkCustomAlphabetLengths(b *testing.B) {
+	lengths := []int{2, 16, 32, 64, 95}
+	for _, alphaLen := range lengths {
+		b.Run(fmt.Sprintf("AlphabetLength%d", alphaLen), func(b *testing.B) {
+			alphabet := makeAlphabet(alphaLen)
+			g, err := New(alphabet, nil)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				_, err := gen.Generate(idLength)
+				_, err := g.Generate(DefaultSize)
 				if err != nil {
-					b.Fatalf("GenerateSize failed: %v", err)
+					b.Fatal(err)
 				}
 			}
 		})
 	}
+}
+
+func BenchmarkCustomAlphabetLengthsParallel(b *testing.B) {
+	lengths := []int{2, 16, 32, 64, 95}
+	for _, alphaLen := range lengths {
+		b.Run(fmt.Sprintf("AlphabetLength%d", alphaLen), func(b *testing.B) {
+			alphabet := makeAlphabet(alphaLen)
+			g, err := New(alphabet, nil)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					_, err := g.Generate(DefaultSize)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}
+
+// Helper function to create an alphabet of a specified length using printable ASCII characters
+func makeAlphabet(length int) string {
+	const (
+		printableASCIIStart = 33  // '!' character
+		printableASCIIEnd   = 126 // '~' character
+	)
+
+	printableASCIIRange := printableASCIIEnd - printableASCIIStart + 1
+
+	if length < 2 {
+		length = 2 // Minimum valid length
+	}
+	if length > printableASCIIRange {
+		length = printableASCIIRange // Maximum valid length
+	}
+
+	alphabet := make([]byte, length)
+	for i := 0; i < length; i++ {
+		alphabet[i] = byte(printableASCIIStart + i)
+	}
+	return string(alphabet)
 }


### PR DESCRIPTION
  - Added a suite of benchmark tests (`nanoid_bench_test.go`) within the `nanoid` package. 
  - Benchmarks cover both serial and concurrent generation of Nano IDs. 
  - Included tests for:
    - Default ID generation using `Generate()` and `GenerateSize()`. 
    - Various ID sizes: 8, 16, 21, 32, 64, 128 characters. 
    - Custom alphabets with varying lengths: 2, 16, 32, 64, 95 characters. 
    - Generation of IDs using custom alphabets both serially and in parallel. 
    - Performance measurement of creating new generator instances.
    - The `makeAlphabet` helper function to generate alphabets using only single-byte, printable ASCII characters.