### PR TITLE
DEFECT: Refactored ID generation functions `newASCII` and `newUnicode` by removing calls to `panic` in favor of returning an `error`

### DIFF
--- a/CHANGELOG/CHANGELOG-1.x.md
+++ b/CHANGELOG/CHANGELOG-1.x.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ---
+## [1.13.1] - 2024-NOV-05
+
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- **DEFECT:** Refactored ID generation functions `newASCII` and `newUnicode` by removing calls to `panic` in favor of returning an `error`.
+### Security
+
+---
 ## [1.13.0] - 2024-NOV-05
 
 ### Added
@@ -255,7 +266,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/scriptures-social/platform/compare/v1.13.0..HEAD
+[Unreleased]: https://github.com/scriptures-social/platform/compare/v1.13.1..HEAD
+[1.13.1]: https://github.com/sixafter/nanoid/compare/v1.13.0...v1.13.1
 [1.13.0]: https://github.com/sixafter/nanoid/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/sixafter/nanoid/compare/v1.11.1...v1.12.0
 [1.11.1]: https://github.com/sixafter/nanoid/compare/v1.11.0...v1.11.1

--- a/nanoid.go
+++ b/nanoid.go
@@ -501,7 +501,7 @@ func (g *generator) newASCII(length int) (string, error) {
 
 			if isPowerOfTwo || int(rnd) < int(g.config.alphabetLen) {
 				if rnd >= uint(len(g.config.byteAlphabet)) {
-					panic(fmt.Sprintf("rnd value %d exceeds byteAlphabet length %d", rnd, len(g.config.byteAlphabet)))
+					return "", fmt.Errorf("rnd value %d exceeds byteAlphabet length %d", rnd, len(g.config.byteAlphabet))
 				}
 				id[cursor] = g.config.byteAlphabet[rnd]
 				cursor++
@@ -576,7 +576,7 @@ func (g *generator) newUnicode(length int) (string, error) {
 
 			if isPowerOfTwo || int(rnd) < int(g.config.alphabetLen) {
 				if rnd >= uint(len(g.config.runeAlphabet)) {
-					panic(fmt.Sprintf("rnd value %d exceeds runeAlphabet length %d", rnd, len(g.config.runeAlphabet)))
+					return "", fmt.Errorf("rnd value %d exceeds runeAlphabet length %d", rnd, len(g.config.runeAlphabet))
 				}
 				idRunes[cursor] = g.config.runeAlphabet[rnd]
 				cursor++


### PR DESCRIPTION
This PR addresses issue #22 