### PR TITLE
defect: ASCII-only detection should use unicode.MaxASCII

### DIFF
--- a/CHANGELOG/CHANGELOG-1.x.md
+++ b/CHANGELOG/CHANGELOG-1.x.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ---
+## [1.13.3] - 2024-NOV-07
+
+### Added
+### Changed
+### Deprecated
+### Removed
+- **DEFECT:** ASCII-only detection now correctly uses `unicode.MaxASCII` instead of `0x7F` to ensure compatibility with all ASCII characters.
+### Fixed
+### Security
+
+---
 ## [1.13.2] - 2024-NOV-06
 
 ### Added
@@ -283,7 +294,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/scriptures-social/platform/compare/v1.13.2..HEAD
+[Unreleased]: https://github.com/scriptures-social/platform/compare/v1.13.3..HEAD
+[1.13.3]: https://github.com/sixafter/nanoid/compare/v1.13.2...v1.13.3
 [1.13.2]: https://github.com/sixafter/nanoid/compare/v1.13.1...v1.13.2
 [1.13.1]: https://github.com/sixafter/nanoid/compare/v1.13.0...v1.13.1
 [1.13.0]: https://github.com/sixafter/nanoid/compare/v1.12.0...v1.13.0

--- a/CHANGELOG/CHANGELOG-1.x.md
+++ b/CHANGELOG/CHANGELOG-1.x.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.13.3] - 2024-NOV-07
 
 ### Added
+- **DEBT:** Added test for `panic` in `MustWithLength` function.
 ### Changed
 ### Deprecated
 ### Removed

--- a/nanoid.go
+++ b/nanoid.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"math/bits"
 	"sync"
+	"unicode"
 	"unicode/utf8"
 )
 
@@ -316,7 +317,7 @@ func buildRuntimeConfig(opts *ConfigOptions) (*runtimeConfig, error) {
 	isASCII := true
 	byteAlphabet := make([]byte, len(alphabetRunes))
 	for i, r := range alphabetRunes {
-		if r > 0x7F { // 127: highest code point in the 7-bit ASCII character set.
+		if r > unicode.MaxASCII {
 			isASCII = false
 			break
 		}

--- a/nanoid_test.go
+++ b/nanoid_test.go
@@ -50,6 +50,16 @@ func TestNewAndMustDefault(t *testing.T) {
 	is.True(isValidID(id, DefaultAlphabet), "Generated ID contains invalid characters")
 }
 
+// TestNewAndMustWithCustomLengthPanic tests the must generation of a NanoID with an invalid length for panic.
+func TestNewAndMustWithCustomLengthPanic(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	is.Panics(func() {
+		MustWithLength(0)
+	})
+}
+
 // TestNewInvalidLength tests the generator's response to invalid lengths.
 func TestNewInvalidLength(t *testing.T) {
 	t.Parallel()
@@ -192,15 +202,17 @@ func TestGetConfig(t *testing.T) {
 	is.Equal(expectedMask, runtimeConfig.Mask(), "Config.Mask should be correctly calculated")
 
 	is.Equal((runtimeConfig.AlphabetLen()&(runtimeConfig.AlphabetLen()-1)) == 0, runtimeConfig.IsPowerOfTwo(), "Config.IsPowerOfTwo should be correct")
-	is.Positive(runtimeConfig.BufferSize(), "Config.BufferSize should be a positive integer")
+	is.Positive(runtimeConfig.BaseMultiplier(), "Config.BaseMultiplier should be a positive integer")
 	is.Positive(runtimeConfig.BitsNeeded(), "Config.BitsNeeded should be a positive integer")
-	is.Positive(runtimeConfig.BytesNeeded(), "Config.BytesNeeded should be a positive integer")
-	is.Equal(rand.Reader, runtimeConfig.RandReader(), "Config.RandReader should be rand.Reader by default")
-	is.Equal(true, runtimeConfig.IsASCII(), "Config.IsASCII should be true by default")
-	is.NotNil(runtimeConfig.RuneAlphabet(), "Config.RuneAlphabet should not be nil")
-	is.NotNil(runtimeConfig.ByteAlphabet(), "Config.ByteAlphabet should not be nil")
 	is.Positive(runtimeConfig.BufferMultiplier(), "Config.BufferMultiplier should be a positive integer")
+	is.Positive(runtimeConfig.BufferSize(), "Config.BufferSize should be a positive integer")
+	is.NotNil(runtimeConfig.ByteAlphabet(), "Config.ByteAlphabet should not be nil")
+	is.Positive(runtimeConfig.BytesNeeded(), "Config.BytesNeeded should be a positive integer")
+	is.Equal(true, runtimeConfig.IsASCII(), "Config.IsASCII should be true by default")
 	is.Positive(runtimeConfig.LengthHint(), "Config.LengthHint should be a positive integer")
+	is.Equal(rand.Reader, runtimeConfig.RandReader(), "Config.RandReader should be rand.Reader by default")
+	is.NotNil(runtimeConfig.RuneAlphabet(), "Config.RuneAlphabet should not be nil")
+	is.Positive(runtimeConfig.ScalingFactor(), "Config.ScalingFactor should be a positive integer")
 }
 
 // TestUniqueness tests that multiple generated IDs are unique.


### PR DESCRIPTION
ASCII-only detection now correctly uses unicode.MaxASCII instead of 0x7F to ensure compatibility with all ASCII characters.