### PR TITLE
debt: Refactored `ID.String` and `ID.Compare` methods to use value receivers

### DIFF
--- a/CHANGELOG/CHANGELOG-1.x.md
+++ b/CHANGELOG/CHANGELOG-1.x.md
@@ -18,6 +18,17 @@ Date format: `YYYY-MM-DD`
 ### Security
 
 ---
+## [1.25.0] - 2025-05-13
+
+### Added
+### Changed
+- **debt**: Refactored `ID.String` and `ID.Compare` methods to use value receivers for improved clarity and consistency with Go idioms. Pointer receivers remain for methods requiring nil checks or mutation.
+
+### Deprecated
+### Removed
+### Fixed
+
+---
 ## [1.24.1] - 2025-05-04
 
 ### Added
@@ -551,7 +562,8 @@ Date format: `YYYY-MM-DD`
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/sixafter/nanoid/compare/v1.24.1...HEAD
+[Unreleased]: https://github.com/sixafter/nanoid/compare/v1.25.0...HEAD
+[1.25.0]: https://github.com/sixafter/nanoid/compare/v1.24.1...v1.25.0
 [1.24.1]: https://github.com/sixafter/nanoid/compare/v1.24.0...v1.24.1
 [1.24.0]: https://github.com/sixafter/nanoid/compare/v1.23.0...v1.24.0
 [1.23.0]: https://github.com/sixafter/nanoid/compare/v1.22.0...v1.23.0

--- a/id.go
+++ b/id.go
@@ -17,6 +17,10 @@ var EmptyID = ID("")
 
 // IsEmpty returns true if the ID is an empty ID (EmptyID)
 func (id *ID) IsEmpty() bool {
+	if id == nil {
+		return true
+	}
+
 	return id.Compare(EmptyID) == 0
 }
 
@@ -35,8 +39,8 @@ func (id *ID) IsEmpty() bool {
 //	id2 := ID("V1StGXR8_Z5jdHi6B-myT")
 //	result := id1.Compare(id2)
 //	fmt.Println(result) // Output: 0
-func (id *ID) Compare(other ID) int {
-	return strings.Compare(string(*id), string(other))
+func (id ID) Compare(other ID) int {
+	return strings.Compare(string(id), string(other))
 }
 
 // String returns the string representation of the ID.
@@ -47,8 +51,8 @@ func (id *ID) Compare(other ID) int {
 //
 //	id := Must()
 //	fmt.Println(id) // Output: V1StGXR8_Z5jdHi6B-myT
-func (id *ID) String() string {
-	return string(*id)
+func (id ID) String() string {
+	return string(id)
 }
 
 // MarshalText converts the ID to a byte slice.


### PR DESCRIPTION

This PR modifies `ID.String` and `ID.Compare` methods to use value receivers  for improved clarity and consistency with Go idioms. Pointer receivers remain for methods requiring nil checks or mutation.