### PR TITLE
risk: Eagerly initialize PRNG pool in NewReader to surface initialization errors at construction time

### DIFF
--- a/CHANGELOG/CHANGELOG-1.x.md
+++ b/CHANGELOG/CHANGELOG-1.x.md
@@ -18,6 +18,21 @@ Date format: `YYYY-MM-DD`
 ### Security
 
 ---
+## [1.36.0] - 2025-07-12
+
+### Added
+- **risk:** Eagerly initialize PRNG pool in NewReader to surface initialization errors at construction time. This addresses issue [#57](https://github.com/sixafter/nanoid/issues/57).
+- **risk:** Added refined steps to verify the signature of the release artifacts using [`cosign`](https://github.com/sigstore/cosign).
+
+### Changed
+- **debt:** Modified benchmark tests to favor use of [`b.Loop()`](https://go.dev/blog/testing-b-loop) over `b.N` to ensure consistent performance across measurements.
+
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+---
 ## [1.35.0] - 2025-07-10
 
 ### Added
@@ -737,7 +752,8 @@ Date format: `YYYY-MM-DD`
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/sixafter/nanoid/compare/v1.35.0...HEAD
+[Unreleased]: https://github.com/sixafter/nanoid/compare/v1.36.0...HEAD
+[1.36.0]: https://github.com/sixafter/nanoid/compare/v1.35.0...v1.36.0
 [1.35.0]: https://github.com/sixafter/nanoid/compare/v1.34.0...v1.35.0
 [1.34.0]: https://github.com/sixafter/nanoid/compare/v1.33.0...v1.34.0
 [1.33.0]: https://github.com/sixafter/nanoid/compare/v1.32.1...v1.33.0

--- a/Makefile
+++ b/Makefile
@@ -39,12 +39,14 @@ fuzz: ## Run each Go fuzz test individually (10s per test)
 
 .PHONY: bench
 bench: ## Execute benchmark tests
+	@rm -f cpu.out
 	@rm -f mem.out
 	$(GO_TEST) -bench=. -benchmem -memprofile=mem.out -cpuprofile=cpu.out
 
 .PHONY: bench-csprng
 bench-csprng: ## Execute benchmark tests for CSPRNG
-	@rm -f mem.out
+	@rm -f x/crypto/prng/cpu.out
+	@rm -f x/crypto/prng/mem.out
 	$(GO_TEST) -bench='^BenchmarkUUID_' -benchmem -memprofile=mem.out -cpuprofile=cpu.out ./x/crypto/prng
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -61,7 +61,12 @@ Please see the [Nano ID CLI](https://github.com/sixafter/nanoid-cli) for a comma
 
 ## Verify with Cosign
 
-Download the source archive and its .sig file from the GitHub release (e.g., nanoid-1.32.0.tar.gz and nanoid-1.32.0.tar.gz.sig ), then run:
+[Cosign](https://github.com/sigstore/cosign) is used to sign releases for integrity verification.
+
+To verify the integrity of the `nanoid` source, first download the target version and its signature file 
+from the [releases page](https://github.com/sixafter/nanoid/releases) along with its `.sig` file; e.g., 
+`nanoid-1.32.0.tar.gz` and `nanoid-1.32.0.tar.gz.sig`. Then run the following command to verify the 
+signature:
 
 ```sh
 # Replace <version> with the release version you downloaded, e.g., 1.32.0
@@ -78,7 +83,7 @@ cosign verify-blob \
   nanoid-1.32.0.tar.gz
 ```
 
-The checksums are also signed (checksums.txt and checksums.txt.sig), verify with:
+The checksums are also signed (`checksums.txt` and `checksums.txt.sig`), verify with:
 
 ```sh
 cosign verify-blob \

--- a/nanoid_benchmark_test.go
+++ b/nanoid_benchmark_test.go
@@ -109,7 +109,7 @@ func Benchmark_Allocations_Serial(b *testing.B) {
 		b.Fatalf("failed to create generator: %v", err)
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err = gen.NewWithLength(idLength)
 	}
 }
@@ -150,7 +150,7 @@ func Benchmark_Read_DefaultLength(b *testing.B) {
 	buffer := make([]byte, DefaultLength)
 	b.ResetTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := Generator.Read(buffer)
 		if err != nil {
 			b.Fatalf("Read returned an unexpected error: %v", err)
@@ -175,7 +175,7 @@ func Benchmark_Read_VaryingBufferSizes(b *testing.B) {
 		b.Run(fmt.Sprintf("BufferSize_%d", size), func(b *testing.B) {
 			buffer := make([]byte, size)
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				_, err := gen.Read(buffer)
 				if err != nil {
 					b.Fatalf("Read returned an unexpected error: %v", err)
@@ -191,7 +191,7 @@ func Benchmark_Read_ZeroLengthBuffer(b *testing.B) {
 	buffer := make([]byte, 0)
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := Generator.Read(buffer)
 		if err != nil {
 			b.Fatalf("Read returned an unexpected error: %v", err)
@@ -239,7 +239,7 @@ func Benchmark_Read_Concurrent(b *testing.B) {
 func Benchmark_Alphabet_Varying_Serial(b *testing.B) {
 	b.ReportAllocs()
 	idLengths := []int{8, 16, 21, 32, 64, 128}
-	mean := mean(idLengths)
+	mn := mean(idLengths)
 	alphabetLengths := []int{2, 16, 32, 64}
 	alphabetTypes := []string{"ASCII", "Unicode"}
 	for _, alphabetType := range alphabetTypes {
@@ -252,7 +252,7 @@ func Benchmark_Alphabet_Varying_Serial(b *testing.B) {
 			}
 			gen, err := NewGenerator(
 				WithAlphabet(alphabet),
-				WithLengthHint(uint16(mean)),
+				WithLengthHint(uint16(mn)),
 			)
 			if err != nil {
 				b.Fatalf("Failed to create generator with %s alphabet of length %d: %v", alphabetType, alphaLen, err)
@@ -261,7 +261,7 @@ func Benchmark_Alphabet_Varying_Serial(b *testing.B) {
 				for _, idLen := range idLengths {
 					b.Run(fmt.Sprintf("IDLen%d", idLen), func(b *testing.B) {
 						b.ResetTimer()
-						for i := 0; i < b.N; i++ {
+						for b.Loop() {
 							_, err := gen.NewWithLength(idLen)
 							if err != nil {
 								b.Fatalf("Failed to generate Nano ID: %v", err)
@@ -325,7 +325,7 @@ func Benchmark_Alphabet_Varying_Length_Varying_Serial(b *testing.B) {
 	alphabetTypes := []string{"ASCII", "Unicode"}
 	alphabetLengths := []int{2, 16, 32, 64}
 	idLengths := []int{8, 16, 21, 32, 64, 128}
-	mean := mean(idLengths)
+	mn := mean(idLengths)
 	for _, alphabetType := range alphabetTypes {
 		for _, alphaLen := range alphabetLengths {
 			var alphabet string
@@ -336,7 +336,7 @@ func Benchmark_Alphabet_Varying_Length_Varying_Serial(b *testing.B) {
 			}
 			gen, err := NewGenerator(
 				WithAlphabet(alphabet),
-				WithLengthHint(uint16(mean)),
+				WithLengthHint(uint16(mn)),
 			)
 			if err != nil {
 				b.Fatalf("Failed to create generator with %s alphabet of length %d: %v", alphabetType, alphaLen, err)
@@ -345,7 +345,7 @@ func Benchmark_Alphabet_Varying_Length_Varying_Serial(b *testing.B) {
 				for _, idLen := range idLengths {
 					b.Run(fmt.Sprintf("IDLen%d", idLen), func(b *testing.B) {
 						b.ResetTimer()
-						for i := 0; i < b.N; i++ {
+						for b.Loop() {
 							_, err := gen.NewWithLength(idLen)
 							if err != nil {
 								b.Fatalf("Failed to generate Nano ID: %v", err)

--- a/nanoid_fuzz_test.go
+++ b/nanoid_fuzz_test.go
@@ -3,12 +3,6 @@
 // This source code is licensed under the Apache 2.0 License found in the
 // LICENSE file in the root directory of this source tree.
 
-// Package prng provides a cryptographically secure pseudo-random number generator (PRNG)
-// that implements the io.Reader interface. It is designed for high-performance, concurrent
-// use in generating random bytes.
-//
-// This package is part of the experimental "x" modules and may be subject to change.
-
 package nanoid
 
 import (

--- a/nanoid_test.go
+++ b/nanoid_test.go
@@ -38,17 +38,17 @@ var (
 // TestNewWithCustomLengths tests the generation of Nano IDs with custom lengths.
 func TestNewWithCustomLengths(t *testing.T) {
 	t.Parallel()
-	lengths := []int{1, 5, 10, 21, 50, 100}
+	lengths := []int{1, 3, 5, 13, 21, 34, 55}
 
 	for _, length := range lengths {
-		length := length // capture range variable
-		t.Run("Length_"+strconv.Itoa(length), func(t *testing.T) {
+		ln := length // capture range variable
+		t.Run("Length_"+strconv.Itoa(ln), func(t *testing.T) {
 			t.Parallel()
 			is := assert.New(t)
 
-			id, err := NewWithLength(length)
-			is.NoError(err, "NewWithLength(%d) should not return an error", length)
-			is.Equal(length, len([]rune(id)), "Generated ID should have the specified length")
+			id, err := NewWithLength(ln)
+			is.NoError(err, "NewWithLength(%d) should not return an error", ln)
+			is.Equal(ln, len([]rune(id)), "Generated ID should have the specified ln")
 
 			is.True(isValidID(id, DefaultAlphabet), "Generated ID contains invalid characters")
 		})
@@ -139,9 +139,9 @@ func TestNewGeneratorWithInvalidAlphabet(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
 
-	lengths := []int{1, 2, 256, 257}
+	lengths := []int{1, 2, 4, 8, 16, 32, 64, 128}
 
-	mean := mean(lengths)
+	mn := mean(lengths)
 
 	// Define the alphabet types to test
 	types := []string{"ASCII", "Unicode"}
@@ -157,7 +157,7 @@ func TestNewGeneratorWithInvalidAlphabet(t *testing.T) {
 			}
 			gen, err := NewGenerator(
 				WithAlphabet(alphabet),
-				WithLengthHint(uint16(mean)),
+				WithLengthHint(uint16(mn)),
 			)
 
 			alphabetRunes := []rune(alphabet)

--- a/x/crypto/prng/README.md
+++ b/x/crypto/prng/README.md
@@ -6,6 +6,8 @@ The `prng` package provides a high-performance, cryptographically secure pseudo-
 that implements the `io.Reader` interface. Designed for concurrent use, it leverages the ChaCha20 cipher stream 
 to efficiently generate random bytes.
 
+Technically, this PRNG is not pseudo-random but is cryptographically random.
+
 The package includes a global `Reader` and a `sync.Pool` to manage PRNG instances, ensuring low contention and 
 optimized performance.
 

--- a/x/crypto/prng/config.go
+++ b/x/crypto/prng/config.go
@@ -8,7 +8,6 @@
 // use in generating random bytes.
 //
 // This package is part of the experimental "x" modules and may be subject to change.
-
 package prng
 
 import (

--- a/x/crypto/prng/config_test.go
+++ b/x/crypto/prng/config_test.go
@@ -8,7 +8,6 @@
 // use in generating random bytes.
 //
 // This package is part of the experimental "x" modules and may be subject to change.
-
 package prng
 
 import (

--- a/x/crypto/prng/prng_benchmark_test.go
+++ b/x/crypto/prng/prng_benchmark_test.go
@@ -25,8 +25,8 @@ func BenchmarkPRNG_ReadSerial(b *testing.B) {
 			buffer := make([]byte, size)
 			b.ResetTimer()   // Reset the timer to exclude setup time
 			b.ReportAllocs() // Report memory allocations
-			for i := 0; i < b.N; i++ {
-				_, err := rdr.Read(buffer)
+			for b.Loop() {
+				_, err = rdr.Read(buffer)
 				if err != nil {
 					b.Fatalf("Read failed: %v", err)
 				}
@@ -39,7 +39,7 @@ func BenchmarkPRNG_ReadSerial(b *testing.B) {
 func BenchmarkPRNG_ReadConcurrent(b *testing.B) {
 	// Define the buffer sizes and goroutine counts to benchmark concurrently.
 	bufferSizes := []int{16, 21, 32, 64, 100, 256, 512, 1000, 4096, 16384}
-	goroutineCounts := []int{10, 100, 1000} // Varying goroutine counts
+	goroutineCounts := []int{1, 2, 4, 8, 16, 32, 64, 128} // Varying goroutine counts
 
 	for _, size := range bufferSizes {
 		for _, gc := range goroutineCounts {
@@ -52,7 +52,7 @@ func BenchmarkPRNG_ReadConcurrent(b *testing.B) {
 					}
 					buffer := make([]byte, size)
 					for pb.Next() {
-						_, err := rdr.Read(buffer)
+						_, err = rdr.Read(buffer)
 						if err != nil {
 							b.Fatalf("Read failed: %v", err)
 						}
@@ -78,8 +78,8 @@ func BenchmarkPRNG_ReadSequentialLargeSizes(b *testing.B) {
 			buffer := make([]byte, size)
 			b.ResetTimer()
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				_, err := rdr.Read(buffer)
+			for b.Loop() {
+				_, err = rdr.Read(buffer)
 				if err != nil {
 					b.Fatalf("Read failed: %v", err)
 				}
@@ -92,7 +92,7 @@ func BenchmarkPRNG_ReadSequentialLargeSizes(b *testing.B) {
 func BenchmarkPRNG_ReadConcurrentLargeSizes(b *testing.B) {
 	// Define large buffer sizes and goroutine counts to benchmark concurrently.
 	largeBufferSizes := []int{4096, 10000, 16384, 65536, 1048576}
-	goroutineCounts := []int{10, 100, 1000} // Varying goroutine counts
+	goroutineCounts := []int{1, 2, 4, 8, 16, 32, 64, 128} // Varying goroutine counts
 
 	for _, size := range largeBufferSizes {
 		for _, gc := range goroutineCounts {
@@ -105,7 +105,7 @@ func BenchmarkPRNG_ReadConcurrentLargeSizes(b *testing.B) {
 					}
 					buffer := make([]byte, size)
 					for pb.Next() {
-						_, err := rdr.Read(buffer)
+						_, err = rdr.Read(buffer)
 						if err != nil {
 							b.Fatalf("Read failed: %v", err)
 						}
@@ -131,8 +131,8 @@ func BenchmarkPRNG_ReadVariableSizes(b *testing.B) {
 			buffer := make([]byte, size)
 			b.ResetTimer()
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				_, err := rdr.Read(buffer)
+			for b.Loop() {
+				_, err = rdr.Read(buffer)
 				if err != nil {
 					b.Fatalf("Read failed: %v", err)
 				}
@@ -145,7 +145,7 @@ func BenchmarkPRNG_ReadVariableSizes(b *testing.B) {
 func BenchmarkPRNG_ReadConcurrentVariableSizes(b *testing.B) {
 	// Define a range of buffer sizes and goroutine counts to benchmark concurrently.
 	variableBufferSizes := []int{8, 16, 21, 24, 32, 48, 64, 128, 256, 512, 1024, 2048, 4096}
-	goroutineCounts := []int{10, 100, 1000}
+	goroutineCounts := []int{1, 2, 4, 8, 16, 32, 64, 128}
 
 	for _, size := range variableBufferSizes {
 		for _, gc := range goroutineCounts {
@@ -158,7 +158,7 @@ func BenchmarkPRNG_ReadConcurrentVariableSizes(b *testing.B) {
 					}
 					buffer := make([]byte, size)
 					for pb.Next() {
-						_, err := rdr.Read(buffer)
+						_, err = rdr.Read(buffer)
 						if err != nil {
 							b.Fatalf("Read failed: %v", err)
 						}
@@ -185,8 +185,8 @@ func BenchmarkPRNG_ReadExtremeSizes(b *testing.B) {
 			buffer := make([]byte, size)
 			b.ResetTimer()
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				_, err := rdr.Read(buffer)
+			for b.Loop() {
+				_, err = rdr.Read(buffer)
 				if err != nil {
 					b.Fatalf("Read failed: %v", err)
 				}
@@ -194,7 +194,7 @@ func BenchmarkPRNG_ReadExtremeSizes(b *testing.B) {
 		})
 
 		// Concurrent Benchmark
-		goroutineCounts := []int{10, 100}
+		goroutineCounts := []int{1, 2, 4, 8, 16, 32, 64, 128}
 		for _, gc := range goroutineCounts {
 			gc := gc // Capture range variable
 			b.Run(fmt.Sprintf("Concurrent_Read_Extreme_%dBytes_%dGoroutines", size, gc), func(b *testing.B) {
@@ -205,7 +205,7 @@ func BenchmarkPRNG_ReadExtremeSizes(b *testing.B) {
 					}
 					buffer := make([]byte, size)
 					for pb.Next() {
-						_, err := rdr.Read(buffer)
+						_, err = rdr.Read(buffer)
 						if err != nil {
 							b.Fatalf("Read failed: %v", err)
 						}

--- a/x/crypto/prng/prng_test.go
+++ b/x/crypto/prng/prng_test.go
@@ -7,12 +7,13 @@ package prng
 import (
 	"bytes"
 	"fmt"
-	"golang.org/x/crypto/chacha20"
 	"io"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"golang.org/x/crypto/chacha20"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/x/crypto/prng/uuid_benchmark_test.go
+++ b/x/crypto/prng/uuid_benchmark_test.go
@@ -54,7 +54,7 @@ func itoa(i int) string {
 func BenchmarkUUID_v4_Default_Serial(b *testing.B) {
 	uuid.SetRand(nil)
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = uuid.New()
 	}
 }
@@ -71,7 +71,7 @@ func BenchmarkUUID_v4_Default_Parallel(b *testing.B) {
 
 func BenchmarkUUID_v4_Default_Concurrent(b *testing.B) {
 	uuid.SetRand(nil)
-	for _, gr := range []int{1, 2, 4, 8, 16, 32, 64, 128} {
+	for _, gr := range []int{4, 8, 16, 32, 64, 128, 256} {
 		b.Run("Goroutines_"+itoa(gr), func(b *testing.B) {
 			benchConcurrent(b, func() { _ = uuid.New() }, gr)
 		})
@@ -83,7 +83,7 @@ func BenchmarkUUID_v4_CSPRNG_Serial(b *testing.B) {
 	uuid.SetRand(Reader)
 	defer uuid.SetRand(nil)
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = uuid.New()
 	}
 }
@@ -102,7 +102,7 @@ func BenchmarkUUID_v4_CSPRNG_Parallel(b *testing.B) {
 func BenchmarkUUID_v4_CSPRNG_Concurrent(b *testing.B) {
 	uuid.SetRand(Reader)
 	defer uuid.SetRand(nil)
-	for _, gr := range []int{1, 2, 4, 8, 16, 32, 64, 128} {
+	for _, gr := range []int{4, 8, 16, 32, 64, 128, 256} {
 		b.Run("Goroutines_"+itoa(gr), func(b *testing.B) {
 			benchConcurrent(b, func() { _ = uuid.New() }, gr)
 		})


### PR DESCRIPTION
This PR addresses the following:

- **risk:** Eagerly initialize PRNG pool in NewReader to surface initialization errors at construction time. This satisfies #57.
- **risk:** Added refined steps to verify the signature of the release artifacts using [`cosign`](https://github.com/sigstore/cosign).
- **debt:** Modified benchmark tests to favor use of [`b.Loop()`](https://go.dev/blog/testing-b-loop) over `b.N` to ensure consistent performance across measurements.
