### PR TITLE
feature: Add support for configurable sharded sync.Pool instances

### DIFF
--- a/CHANGELOG/CHANGELOG-1.x.md
+++ b/CHANGELOG/CHANGELOG-1.x.md
@@ -18,6 +18,19 @@ Date format: `YYYY-MM-DD`
 ### Security
 
 ---
+## [1.40.0] - 2025-07-17
+
+### Added
+### Changed
+- **feature:** - Added support configurable sharded `sync.Pool` instances in [`prng`](../x/crypto/prng) and [`ctrdrbg`](../x/crypto/ctrdrbg) for improved concurrency and throughput.
+  - The number of shards defaults to `runtime.GOMAXPROCS(0)`, which is useful in containerized or CPU-constrained environments pending https://github.com/golang/go/issues/73193.
+
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+---
 ## [1.39.0] - 2025-07-16
 
 ### Added
@@ -809,7 +822,8 @@ Date format: `YYYY-MM-DD`
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/sixafter/nanoid/compare/v1.39.0...HEAD
+[Unreleased]: https://github.com/sixafter/nanoid/compare/v1.40.0...HEAD
+[1.40.0]: https://github.com/sixafter/nanoid/compare/v1.39.0...v1.40.0
 [1.39.0]: https://github.com/sixafter/nanoid/compare/v1.38.0...v1.39.0
 [1.38.0]: https://github.com/sixafter/nanoid/compare/v1.37.0...v1.38.0
 [1.37.0]: https://github.com/sixafter/nanoid/compare/v1.36.0...v1.37.0

--- a/x/crypto/ctrdrbg/README.md
+++ b/x/crypto/ctrdrbg/README.md
@@ -11,7 +11,7 @@ No third-party, homegrown, or experimental ciphers are used.
 
 ## Features
 
-- **Deterministic Random Bit Generation:** Implements AES-CTR-DRBG as specified in NIST SP 800-90A, Revision 1.
+- **Deterministic Random Bit Generation:** Implements AES-CTR-DRBG as specified in [NIST SP 800-90A, Revision 1](https://csrc.nist.gov/pubs/sp/800/90/a/r1/final).
 - **FIPS‑140 Mode Compatible:** Designed to run in FIPS‑140 validated environments using only Go standard library crypto.
     - For details and deployment guidance, see [FIPS‑140.md](../../../FIPS-140.md).
 - **Stateless and Concurrent:** Safe for concurrent use and supports stateless operation with independent DRBG instances.
@@ -31,7 +31,29 @@ go get -u github.com/sixafter/nanoid/x/crypto/ctrdrbg
 
 ## Usage
 
-### Basic Usage: Generate Secure Random Bytes
+### Basic Usage: Generate Secure Random Bytes With Reader
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/sixafter/nanoid/x/crypto/ctrdrbg"
+)
+
+func main() {
+	buf := make([]byte, 64)
+	n, err := ctrdrbg.Reader.Read(buf)
+	if err != nil {
+		log.Fatalf("failed to read random bytes: %v", err)
+	}
+	fmt.Printf("Read %d random bytes: %x\n", n, buf)
+}
+```
+
+### Basic Usage: Generate Secure Random Bytes with NewReader
 
 ```go
 package main
@@ -59,27 +81,6 @@ func main() {
 }
 ```
 
-### Basic Usage: With Personalization
-
-```go
-package main
-
-import (
-	"fmt"
-	"log"
-
-	"github.com/sixafter/nanoid/x/crypto/ctrdrbg"
-)
-
-func main() {
-	buf := make([]byte, 64)
-	n, err := ctrdrbg.Reader.Read(buf)
-	if err != nil {
-		log.Fatalf("failed to read random bytes: %v", err)
-	}
-	fmt.Printf("Read %d random bytes: %x\n", n, buf)
-}
-```
 ### Using Personalization and Additional Input
 
 ```go

--- a/x/crypto/ctrdrbg/aes_ctr_drbg_bench_test.go
+++ b/x/crypto/ctrdrbg/aes_ctr_drbg_bench_test.go
@@ -12,8 +12,8 @@ import (
 
 // For benchmarking sync.Pool get/put only (DRBG instancing contention, not output).
 func (r *reader) syncPoolGetPut() {
-	dr := r.pool.Get().(*drbg)
-	r.pool.Put(dr)
+	dr := r.pools[0].Get().(*drbg)
+	r.pools[0].Put(dr)
 }
 
 func BenchmarkDRBG_Concurrent_SyncPool_Baseline(b *testing.B) {

--- a/x/crypto/ctrdrbg/config_test.go
+++ b/x/crypto/ctrdrbg/config_test.go
@@ -133,6 +133,16 @@ func TestConfig_WithDefaultBufferSize(t *testing.T) {
 	is.Equal(64, cfg.DefaultBufferSize, "WithDefaultBufferSize should set DefaultBufferSize")
 }
 
+// TestConfig_WithShards ensures that WithShards updates only the Shards field.
+func TestConfig_WithShards(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	cfg := DefaultConfig()
+	WithShards(8)(&cfg)
+	is.Equal(8, cfg.Shards, "WithShards should override Shards")
+}
+
 // TestConfig_CombinedOptions ensures multiple options can be applied sequentially.
 func TestConfig_CombinedOptions(t *testing.T) {
 	t.Parallel()

--- a/x/crypto/prng/config_test.go
+++ b/x/crypto/prng/config_test.go
@@ -162,6 +162,16 @@ func TestConfig_WithMaxRekeyBackoff(t *testing.T) {
 	is.Equal(100*time.Millisecond, cfg.RekeyBackoff)
 }
 
+// TestConfig_WithShards ensures that WithShards updates only the Shards field.
+func TestConfig_WithShards(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	cfg := DefaultConfig()
+	WithShards(8)(&cfg)
+	is.Equal(8, cfg.Shards, "WithShards should override Shards")
+}
+
 // TestConfig_AllOptions verifies that all option functions can be composed
 // and applied together, each updating their corresponding field in the Config struct.
 func TestConfig_AllOptions(t *testing.T) {

--- a/x/crypto/prng/prng.go
+++ b/x/crypto/prng/prng.go
@@ -15,6 +15,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	mrand "math/rand/v2"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -45,11 +46,33 @@ var Reader io.Reader
 // it ensures that any critical failure in obtaining a secure entropy source
 // is detected immediately and cannot be ignored.
 func init() {
-	var err error
-	Reader, err = NewReader()
-	if err != nil {
-		panic(fmt.Sprintf("prng.init: failed to create Reader: %v", err))
+	cfg := DefaultConfig()
+	pools := make([]*sync.Pool, cfg.Shards)
+	for i := range pools {
+		cfg := cfg // Capture the current configuration for this shard
+		pools[i] = &sync.Pool{
+			New: func() interface{} {
+				var (
+					p   *prng
+					err error
+				)
+				for r := 0; r < cfg.MaxInitRetries; r++ {
+					if p, err = newPRNG(&cfg); err == nil {
+						return p
+					}
+				}
+				// If initialization fails after all retries, panic.
+				panic(fmt.Sprintf("prng pool init failed after %d retries: %v", cfg.MaxInitRetries, err))
+			},
+		}
+
+		// Eagerly test the pool initialization to ensure that any catastrophic
+		// failure is caught immediately, not deferred to the first use.
+		item := pools[i].Get().(*prng)
+		pools[i].Put(item)
 	}
+
+	Reader = &reader{pools: pools}
 }
 
 // reader wraps a sync.Pool of prng instances to provide an io.Reader
@@ -62,7 +85,7 @@ func init() {
 // minimizes allocations and contention on crypto/rand while ensuring
 // each goroutine can obtain a fresh or recycled PRNG instance quickly.
 type reader struct {
-	pool *sync.Pool
+	pools []*sync.Pool
 }
 
 // NewReader constructs and returns an io.Reader that produces cryptographically secure
@@ -100,43 +123,62 @@ func NewReader(opts ...Option) (io.Reader, error) {
 	// The pool's New function attempts to construct a new *prng,
 	// retrying up to cfg.MaxInitRetries times in case of failure (e.g., low entropy).
 	// If all attempts fail, the function panics—making the error immediately visible to the developer.
-	pool := &sync.Pool{
-		New: func() interface{} {
-			var (
-				p   *prng
-				err error
-			)
-			for i := 0; i < cfg.MaxInitRetries; i++ {
-				if p, err = newPRNG(&cfg); err == nil {
-					return p
+	pools := make([]*sync.Pool, cfg.Shards)
+	for i := range pools {
+		cfg := cfg // Capture the current configuration for this shard
+		pools[i] = &sync.Pool{
+			New: func() interface{} {
+				var (
+					p   *prng
+					err error
+				)
+				for r := 0; r < cfg.MaxInitRetries; r++ {
+					if p, err = newPRNG(&cfg); err == nil {
+						return p
+					}
 				}
-			}
-			// If initialization fails after all retries, panic.
-			panic(fmt.Sprintf("prng pool init failed after %d retries: %v", cfg.MaxInitRetries, err))
-		},
-	}
+				// If initialization fails after all retries, panic.
+				panic(fmt.Sprintf("prng pool init failed after %d retries: %v", cfg.MaxInitRetries, err))
+			},
+		}
 
-	// Step 3: Eagerly test the pool initialization to ensure that any catastrophic
-	// failure is caught immediately, not deferred to the first use.
-	// This triggers pool.New, which may panic on failure. The panic is recovered and stored as an error.
-	var panicErr error
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				panicErr = fmt.Errorf("prng pool initialization failed: %v", r)
-			}
+		// Step 3: Eagerly test the pool initialization to ensure that any catastrophic
+		// failure is caught immediately, not deferred to the first use.
+		// This triggers pool.New, which may panic on failure. The panic is recovered and stored as an error.
+		var panicErr error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					panicErr = fmt.Errorf("prng pool initialization failed: %v", r)
+				}
+			}()
+			item := pools[i].Get().(*prng)
+			pools[i].Put(item)
 		}()
-		item := pool.Get()
-		pool.Put(item)
-	}()
 
-	// Step 4: If initialization failed with a panic, return it as an error.
-	if panicErr != nil {
-		return nil, panicErr
+		// Step 4: If initialization failed with a panic, return it as an error.
+		if panicErr != nil {
+			return nil, panicErr
+		}
 	}
 
 	// Step 5: Return a new reader that wraps the initialized pool. This is safe for concurrent use.
-	return &reader{pool: pool}, nil
+	return &reader{pools: pools}, nil
+}
+
+// shardIndex selects a pseudo-random shard index in the range [0, n) using
+// a fast, thread-safe global PCG64-based RNG.
+//
+// This function is used to evenly distribute load across multiple sync.Pool
+// shards, reducing contention in high-concurrency scenarios. It avoids the
+// overhead of time-based seeding or mutex contention.
+//
+// The randomness is not cryptographically secure but is safe for concurrent
+// use and sufficient for load balancing purposes.
+//
+// Panics if n <= 0.
+func shardIndex(n int) int {
+	return mrand.IntN(n)
 }
 
 // Read fills the provided buffer with cryptographically secure random data.
@@ -160,13 +202,19 @@ func (r *reader) Read(b []byte) (int, error) {
 		return 0, nil
 	}
 
+	// Determine the shard index based on the number of pools available.
+	shard := len(r.pools) - 1
+	if shard > 1 {
+		shard = shardIndex(shard)
+	}
+
 	// Step 2: Acquire a PRNG instance from the pool for exclusive use by this call.
 	// This provides thread safety and isolation of cryptographic state.
-	p := r.pool.Get().(*prng)
+	p := r.pools[shard].Get().(*prng)
 
 	// Step 3: Always return the PRNG instance to the pool, even if an error occurs.
 	// This ensures that the pool does not leak resources and stays available for future use.
-	defer r.pool.Put(p)
+	defer r.pools[shard].Put(p)
 
 	// Step 4: Delegate the actual generation of random bytes to the PRNG instance's Read method.
 	return p.Read(b)

--- a/x/crypto/prng/prng_benchmark_test.go
+++ b/x/crypto/prng/prng_benchmark_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func (r *reader) syncPoolGetPut() {
-	p := r.pool.Get().(*prng)
-	r.pool.Put(p)
+	p := r.pools[0].Get().(*prng)
+	r.pools[0].Put(p)
 }
 
 func BenchmarkPRNG_Concurrent_SyncPool_Baseline(b *testing.B) {


### PR DESCRIPTION
Both prng and ctrdrbg add support for the number of shards defaults to runtime.GOMAXPROCS(0), which is useful in containerized or CPU-constrained environments (see golang/go#73193)