### PR TITLE
defect: Addressed issue in shared `sync.Pool` logic where the index as off by 1, causing unexpected behavior when shards are greater than 1

### DIFF
--- a/CHANGELOG/CHANGELOG-1.x.md
+++ b/CHANGELOG/CHANGELOG-1.x.md
@@ -28,6 +28,8 @@ Date format: `YYYY-MM-DD`
 ### Deprecated
 ### Removed
 ### Fixed
+- **defect:** Addressed issue in shared `sync.Pool` logic where the index was off by 1, causing unexpected behavior when shards are greater than 1.
+
 ### Security
 
 ---

--- a/x/crypto/ctrdrbg/aes_ctr_drbg.go
+++ b/x/crypto/ctrdrbg/aes_ctr_drbg.go
@@ -215,9 +215,10 @@ func (r *reader) Read(b []byte) (int, error) {
 	}
 
 	// Determine the shard index based on the number of pools available.
-	shard := len(r.pools) - 1
-	if shard > 1 {
-		shard = shardIndex(shard)
+	n := len(r.pools)
+	shard := 0
+	if n > 1 {
+		shard = shardIndex(n)
 	}
 
 	// Step 2: Borrow an instance of the internal deterministic random bit generator from the pool.

--- a/x/crypto/prng/prng.go
+++ b/x/crypto/prng/prng.go
@@ -203,9 +203,10 @@ func (r *reader) Read(b []byte) (int, error) {
 	}
 
 	// Determine the shard index based on the number of pools available.
-	shard := len(r.pools) - 1
-	if shard > 1 {
-		shard = shardIndex(shard)
+	n := len(r.pools)
+	shard := 0
+	if n > 1 {
+		shard = shardIndex(n)
 	}
 
 	// Step 2: Acquire a PRNG instance from the pool for exclusive use by this call.


### PR DESCRIPTION
This PR addresses issue #64