### PR TITLE
Unique ctrdrbg streams; add Config(); docs update

### DIFF
--- a/CHANGELOG/CHANGELOG-1.x.md
+++ b/CHANGELOG/CHANGELOG-1.x.md
@@ -15,6 +15,24 @@ Date format: `YYYY-MM-DD`
 ### Deprecated
 ### Removed
 ### Fixed
+
+### 
+
+---
+## [1.41.0] - 2025-07-18
+
+### Added
+- **feature:** Added `Config()` method to both `prng` and `ctrdrbg` implementations to retrieve the current configuration of the generator.
+
+### Changed
+- **debt:** Updated documentation to reflect consistency across `prng` and `ctrdrbg` implementations.
+- **debt:** Updated documentation to clarify FIPS-140 usage and compliance.
+
+### Deprecated
+### Removed
+### Fixed
+- **defect**: Guarantee unique cryptographic stream per [`ctrdrbg.Reader`](../x/crypto/ctrdrbg) instance by persisting and synchronizing internal counter state across all `Read` operations.
+
 ### Security
 
 ---
@@ -824,7 +842,8 @@ Date format: `YYYY-MM-DD`
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/sixafter/nanoid/compare/v1.40.0...HEAD
+[Unreleased]: https://github.com/sixafter/nanoid/compare/v1.41.0...HEAD
+[1.41.0]: https://github.com/sixafter/nanoid/compare/v1.40.0...v1.41.0
 [1.40.0]: https://github.com/sixafter/nanoid/compare/v1.39.0...v1.40.0
 [1.39.0]: https://github.com/sixafter/nanoid/compare/v1.38.0...v1.39.0
 [1.38.0]: https://github.com/sixafter/nanoid/compare/v1.37.0...v1.38.0

--- a/Makefile
+++ b/Makefile
@@ -41,31 +41,31 @@ fuzz: ## Run each Go fuzz test individually (10s per test)
 bench: ## Execute benchmark tests for NanoID
 	@rm -f cpu.out
 	@rm -f mem.out
-	$(GO_TEST) -bench=. -benchmem -memprofile=mem.out -cpuprofile=cpu.out
+	$(GO_TEST) -bench=. -run=^$$ -benchmem -memprofile=mem.out -cpuprofile=cpu.out
 
 .PHONY: bench-csprng
 bench-csprng: ## Execute benchmark tests for CSPRNG (raw bytes).
 	@rm -f x/crypto/prng/cpu.out
 	@rm -f x/crypto/prng/mem.out
-	$(GO_TEST) -bench='^BenchmarkPRNG_' -benchmem -memprofile=x/crypto/prng/mem.out -cpuprofile=x/crypto/prng/cpu.out ./x/crypto/prng
+	$(GO_TEST) -bench='^BenchmarkPRNG_' -run=^$$ -benchmem -memprofile=x/crypto/prng/mem.out -cpuprofile=x/crypto/prng/cpu.out ./x/crypto/prng
 
 .PHONY: bench-csprng-uuid
 bench-csprng-uuid: ## Execute benchmark tests for using the CSPRNG to generate UUIDs using Google's uuid package.
 	@rm -f x/crypto/prng/cpu.out
 	@rm -f x/crypto/prng/mem.out
-	$(GO_TEST) -bench='^BenchmarkUUID_' -benchmem -memprofile=x/crypto/prng/mem.out -cpuprofile=x/crypto/prng/cpu.out ./x/crypto/prng
+	$(GO_TEST) -bench='^BenchmarkUUID_' -run=^$$ -benchmem -memprofile=x/crypto/prng/mem.out -cpuprofile=x/crypto/prng/cpu.out ./x/crypto/prng
 
 .PHONY: bench-ctrdrbg
 bench-ctrdrbg: ## Execute benchmark tests for AES-CTR-DRBG (raw bytes).
 	@rm -f x/crypto/ctrdrbg/cpu.out
 	@rm -f x/crypto/ctrdrbg/mem.out
-	$(GO_TEST) -bench='^BenchmarkDRBG_' -benchmem -memprofile=x/crypto/ctrdrbg/mem.out -cpuprofile=x/crypto/ctrdrbg/cpu.out ./x/crypto/ctrdrbg
+	$(GO_TEST) -bench='^BenchmarkDRBG_' -run=^$$ -benchmem -memprofile=x/crypto/ctrdrbg/mem.out -cpuprofile=x/crypto/ctrdrbg/cpu.out ./x/crypto/ctrdrbg
 
 .PHONY: bench-ctrdrbg-uuid
 bench-ctrdrbg-uuid: ## Execute benchmark tests for using the AES-CTR-DRBG to generate UUIDs using Google's uuid package.
 	@rm -f x/crypto/ctrdrbg/cpu.out
 	@rm -f x/crypto/ctrdrbg/mem.out
-	$(GO_TEST) -bench='^BenchmarkUUID_' -benchmem -memprofile=x/crypto/ctrdrbg/mem.out -cpuprofile=x/crypto/ctrdrbg/cpu.out ./x/crypto/ctrdrbg
+	$(GO_TEST) -bench='^BenchmarkUUID_' -run=^$$ -benchmem -memprofile=x/crypto/ctrdrbg/mem.out -cpuprofile=x/crypto/ctrdrbg/cpu.out ./x/crypto/ctrdrbg
 
 .PHONY: clean
 clean: ## Remove previous build

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ Please see the [godoc](https://pkg.go.dev/github.com/sixafter/nanoid) for detail
   - The Nano ID generator satisfies the `io.Reader` interface, allowing it to be used interchangeably with any `io.Reader` implementations. 
   - Developers can utilize the Nano ID generator in contexts such as streaming data processing, pipelines, and other I/O-driven operations.
 - **FIPS‑140 Mode Compatible**: Designed to run in FIPS‑140 validated environments using only Go standard library crypto. 
-  - For FIPS‑140 compatible random number generation, use the [x/crypto/ctrdrbg](x/crypto/ctrdrbg) module.
+  - For FIPS‑140 compatible random number generation, use the [x/crypto/ctrdrbg](x/crypto/ctrdrbg) package.
   - See [FIPS‑140.md](FIPS-140.md) for details and deployment guidance.
 
-Please see the [nanoid-cli](https://github.com/sixafter/nanoid-cli) for a command-line interface (CLI) that uses this package to generate NanoIDs.
+Please see the [nanoid-cli](https://github.com/sixafter/nanoid-cli) for a command-line interface (CLI) that uses this module to generate Nano IDs.
 
 ---
 
@@ -74,23 +74,23 @@ from the [releases page](https://github.com/sixafter/nanoid/releases) along with
 signature:
 
 ```sh
-# Replace <version> with the release version you downloaded, e.g., 1.32.0
+# Fetch the latest release tag from GitHub API (e.g., "v1.41.0")
+TAG=$(curl -s https://api.github.com/repos/sixafter/nanoid/releases/latest | jq -r .tag_name)
 
+# Remove leading "v" for filenames (e.g., "v1.41.0" -> "1.41.0")
+VERSION=${TAG#v}
+
+# Verify the release tarball
 cosign verify-blob \
   --key https://raw.githubusercontent.com/sixafter/nanoid/main/cosign.pub \
-  --signature nanoid-<version>.tar.gz.sig \
-  nanoid-<version>.tar.gz
+  --signature nanoid-${VERSION}.tar.gz.sig \
+  nanoid-${VERSION}.tar.gz
 
-# Example with version 1.32.0:
-cosign verify-blob \
-  --key https://raw.githubusercontent.com/sixafter/nanoid/main/cosign.pub \
-  --signature nanoid-1.32.0.tar.gz.sig \
-  nanoid-1.32.0.tar.gz
-```
+# Download checksums.txt and its signature from the latest release assets
+curl -LO https://github.com/sixafter/nanoid/releases/download/${TAG}/checksums.txt
+curl -LO https://github.com/sixafter/nanoid/releases/download/${TAG}/checksums.txt.sig
 
-The checksums are also signed (`checksums.txt` and `checksums.txt.sig`), verify with:
-
-```sh
+# Verify checksums.txt with cosign
 cosign verify-blob \
   --key https://raw.githubusercontent.com/sixafter/nanoid/main/cosign.pub \
   --signature checksums.txt.sig \

--- a/x/crypto/ctrdrbg/aes_ctr_drbg.go
+++ b/x/crypto/ctrdrbg/aes_ctr_drbg.go
@@ -42,6 +42,23 @@ import (
 //	fmt.Printf("Random data: %x\n", buf)
 var Reader io.Reader
 
+// Interface defines the contract for a NIST SP 800-90A AES-CTR-DRBG random source.
+//
+// Implementations provide cryptographically secure random bytes via io.Reader,
+// and expose the non-secret, immutable configuration used at construction time.
+//
+// All methods are safe for concurrent use unless otherwise specified.
+//
+// The Config() method returns a copy of the DRBG's configuration. This allows inspection
+// of operational parameters without exposing secrets or runtime-internal state.
+type Interface interface {
+	io.Reader
+
+	// Config returns a copy of the DRBG configuration in use by this instance.
+	// The returned Config does not include secrets or mutable runtime state.
+	Config() Config
+}
+
 // init initializes the package-level Reader. It panics if NewReader fails, preventing operation without
 // a secure random source. This follows cryptographic best practices by making entropy failure a fatal error.
 func init() {
@@ -100,28 +117,7 @@ type reader struct {
 //	    // handle error
 //	}
 //	fmt.Printf("Read %d bytes: %x\n", n, buf)
-//
-// NewReader constructs and returns an io.Reader that produces cryptographically secure
-// random bytes using a pool of AES-CTR-DRBG instances. Functional options may be supplied to customize key size,
-// key rotation, and pool behavior. Each generator is seeded with entropy from crypto/rand.
-//
-// The returned Reader is safe for concurrent use. If no generator can be created after MaxInitRetries,
-// NewReader returns an error.
-//
-// Example:
-//
-//	r, err := ctrdrbg.NewReader(ctrdrbg.WithKeySize(32))
-//	if err != nil {
-//	    // handle error
-//	}
-//
-//	buf := make([]byte, 32)
-//	n, err := r.Read(buf)
-//	if err != nil {
-//	    // handle error
-//	}
-//	fmt.Printf("Read %d bytes: %x\n", n, buf)
-func NewReader(opts ...Option) (io.Reader, error) {
+func NewReader(opts ...Option) (Interface, error) {
 	// Step 1: Start with a default configuration, then apply each functional option to mutate cfg.
 	cfg := DefaultConfig()
 	for _, opt := range opts {
@@ -130,8 +126,10 @@ func NewReader(opts ...Option) (io.Reader, error) {
 
 	// Step 2: Validate the configured key size is appropriate for AES.
 	// Only 16, 24, or 32 bytes (AES-128, AES-192, AES-256) are supported.
-	if cfg.KeySize != 16 && cfg.KeySize != 24 && cfg.KeySize != 32 {
-		return nil, fmt.Errorf("invalid key size: must be 16, 24, or 32 bytes")
+	switch cfg.KeySize {
+	case KeySize128, KeySize192, KeySize256:
+	default:
+		return nil, fmt.Errorf("invalid key size %d bytes; must be 16, 24, or 32", cfg.KeySize)
 	}
 
 	// Step 3: Create a sync.Pool to manage DRBG instances for concurrent access.
@@ -178,6 +176,19 @@ func NewReader(opts ...Option) (io.Reader, error) {
 
 	// Step 6: Return a new reader that wraps the initialized pool.
 	return &reader{pools: pools}, nil
+}
+
+// Config returns a copy of the deterministic random bit generator’s static configuration.
+//
+// This method exposes only non-sensitive configuration options as set at initialization.
+// No secret key material, runtime state, or internal DRBG details are included in the result.
+// The returned Config is a copy and safe for inspection or serialization.
+func (r *reader) Config() Config {
+	// It's safe to fetch from any pool, as all configs are the same.
+	d := r.pools[0].Get().(*drbg)
+	cfg := *d.config
+	r.pools[0].Put(d)
+	return cfg
 }
 
 // shardIndex selects a pseudo-random shard index in the range [0, n) using
@@ -234,46 +245,15 @@ func (r *reader) Read(b []byte) (int, error) {
 	return d.Read(b)
 }
 
-// drbg represents an internal deterministic random bit generator (DRBG) implementing
-// the io.Reader interface using the NIST SP 800-90A AES-CTR-DRBG construction.
-//
-// Each drbg instance is intended to be used by a single goroutine at a time and is not
-// safe for concurrent use. It maintains its own AES cipher, secret key, counter, usage counter,
-// and rekeying flag for key rotation.
-type drbg struct {
-	// config holds the immutable configuration for this DRBG instance.
-	//
-	// Includes:
-	// - AES key size (e.g., 16, 24, or 32 bytes)
-	// - Personalization string for domain separation
-	// - Automatic key rotation policy
-	// - Pool initialization and retry settings
-	config *Config
-
+// state encapsulates the immutable cryptographic state of the DRBG, excluding the counter.
+// This state is swapped atomically on rekey.
+type state struct {
 	// block is the initialized AES cipher.Block used in CTR mode.
 	//
 	// AES-CTR transforms the block cipher into a stream cipher by
 	// encrypting a counter and XOR-ing it with plaintext to produce
 	// pseudorandom output bytes.
 	block cipher.Block
-
-	// zero is a preallocated slice of zero-filled bytes used for XOR operations.
-	//
-	// When UseZeroBuffer is enabled in config, this buffer is XOR-ed with
-	// AES-CTR output to efficiently produce random bytes.
-	zero []byte
-
-	// usage tracks the number of bytes generated since the last key rotation.
-	//
-	// When usage exceeds config.MaxBytesPerKey, a rekey is triggered to ensure
-	// forward secrecy and mitigate key compromise risk.
-	usage uint64
-
-	// rekeying is an atomic flag (0 or 1) that guards rekey attempts.
-	//
-	// It ensures that only one goroutine performs rekeying at a time.
-	// Uses atomic operations for concurrency safety.
-	rekeying uint32
 
 	// key holds the internal DRBG secret key used for AES-CTR operations.
 	//
@@ -292,42 +272,126 @@ type drbg struct {
 	v [16]byte
 }
 
+// drbg represents an internal deterministic random bit generator (DRBG) implementing
+// the io.Reader interface using the NIST SP 800-90A AES-CTR-DRBG construction.
+//
+// Each drbg instance is intended to be used by a single goroutine at a time and is not
+// safe for concurrent use. It maintains its own AES cipher, secret key, counter, usage counter,
+// and rekeying flag for key rotation.
+//
+// This implementation ensures FIPS 140-2 alignment, strong security, and high performance
+// under concurrent workloads by separating immutable cryptographic state (managed atomically)
+// from the evolving counter (protected by a mutex).
+type drbg struct {
+	// config holds the immutable configuration for this DRBG instance.
+	//
+	// Includes:
+	// - AES key size (e.g., 16, 24, or 32 bytes)
+	// - Personalization string for domain separation
+	// - Automatic key rotation policy
+	// - Pool initialization and retry settings
+	config *Config
+
+	// state is an atomic pointer to the immutable cryptographic state for this DRBG.
+	//
+	// This state includes:
+	//   - AES block cipher (used in CTR mode)
+	//   - Secret key material
+	//   - Initial counter value (NIST "V") at creation or rekey
+	//
+	// The atomic pointer allows for fast, race-free swapping of key/counter/cipher state
+	// during asynchronous rekeying, without impacting ongoing read operations.
+	state atomic.Pointer[state]
+
+	// zero is a preallocated slice of zero-filled bytes used for output buffering.
+	//
+	// When UseZeroBuffer is enabled in config, this buffer is XOR-ed with
+	// AES-CTR output to efficiently produce random bytes. Sized dynamically as needed.
+	zero []byte
+
+	// vMu is a mutex protecting the evolving counter (v) for this DRBG instance.
+	//
+	// All access and mutation of v must occur with this mutex held to ensure:
+	//   - Counter advancement is atomic and non-overlapping across reads
+	//   - Proper persistence of the counter value between consecutive reads
+	//   - Safe resetting of the counter during key rotation (rekey)
+	vMu sync.Mutex
+
+	// v is the current 128-bit internal counter (NIST "V") for the DRBG instance.
+	//
+	// This counter is incremented for each AES block produced, ensuring
+	// unique, non-repeating output for every call to Read. It is initialized
+	// from the state.v value at creation or rekey, and persisted between reads.
+	v [16]byte
+
+	// usage tracks the number of bytes generated since the last key rotation.
+	//
+	// When usage exceeds config.MaxBytesPerKey, a rekey is triggered to ensure
+	// forward secrecy and mitigate key compromise risk. This value is atomically updated.
+	usage uint64
+
+	// rekeying is an atomic flag (0 or 1) that guards rekey attempts.
+	//
+	// It ensures that only one goroutine performs rekeying at a time.
+	// Uses atomic operations for concurrency safety.
+	rekeying uint32
+}
+
 // Read generates cryptographically secure random bytes and writes them into the provided slice b.
 //
-// This method implements the io.Reader interface for drbg. It is not safe for concurrent
-// use by multiple goroutines on the same instance. Each call should be exclusive to a single goroutine.
+// This method implements the io.Reader interface for drbg, providing a FIPS 140-2 aligned
+// deterministic random bit generator using the AES-CTR-DRBG construction. Each call to Read
+// returns a unique cryptographically strong pseudo-random stream and is safe for concurrent use.
 //
-// Behavior:
-//   - Fills b with pseudorandom output using AES in counter mode (CTR).
-//   - Processes b in 16-byte (AES block size) chunks. For each block, increments the internal counter (v),
-//     encrypts it, and copies the result into b.
-//   - Tracks the total number of bytes generated in the usage counter. If key rotation is enabled and
-//     the usage exceeds MaxBytesPerKey, attempts to trigger an asynchronous key rotation (asyncRekey).
-//   - Only one goroutine will perform the key rotation at a time. Key rotation is non-blocking.
+// Semantics and Implementation Details:
+//   - A snapshot of the current cryptographic state (key, block cipher, initial counter value) is loaded atomically.
+//   - The DRBG's internal counter (v) is protected by a mutex to guarantee atomic advancement and persistence
+//     between consecutive reads. This ensures that no two Read calls can produce overlapping output, and that
+//     the generator stream is continuous and non-repeating.
+//   - After generating the requested output, the advanced counter is persisted back to the DRBG instance.
+//   - If key rotation is enabled and the generated output exceeds the configured threshold, an asynchronous
+//     rekey operation is triggered. Rekeying swaps the cryptographic state atomically and resets the counter
+//     (under lock) to guarantee forward secrecy and FIPS alignment.
 //
 // Parameters:
-//   - b: The output buffer to be filled with random bytes.
+//   - b: Output buffer to be filled with cryptographically secure random bytes.
 //
 // Returns:
-//   - int: The number of bytes written (equal to len(b), unless b is empty).
-//   - error: Always nil in normal operation. Errors only occur on programmer misuse or internal misconfiguration.
-//
-// Example:
-//
-//	buf := make([]byte, 32)
-//	_, err := drbgInstance.Read(buf)
-//	if err != nil {
-//	    // handle error
-//	}
-//	fmt.Printf("Random bytes: %x\n", buf)
+//   - int: Number of bytes written (equal to len(b) unless b is empty).
+//   - error: Always nil under normal operation.
 func (d *drbg) Read(b []byte) (int, error) {
-	if len(b) == 0 {
+	// Step 1: Return immediately if the buffer is empty, as required by the io.Reader contract.
+	n := len(b)
+	if n == 0 {
 		return 0, nil
 	}
 
-	d.fillBlocks(b)
+	// Atomically load the current DRBG cryptographic state.
+	st := d.state.Load()
 
-	// Usage and rekey logic centralized here
+	// Lock the counter mutex to guarantee exclusive access to the evolving counter.
+	d.vMu.Lock()
+	var v [16]byte
+
+	// Copy the current counter value to a local variable. This snapshot forms the basis
+	// of the unique keystream for this read operation.
+	copy(v[:], d.v[:])
+
+	// Fill the output buffer using the current cryptographic state and the local counter,
+	// incrementing the counter as output is produced. All counter increments are reflected
+	// in the local variable.
+	d.fillBlocks(b, st, &v)
+
+	// Persist the advanced counter back to the DRBG instance, ensuring subsequent reads
+	// continue the keystream seamlessly without overlap or repetition.
+	copy(d.v[:], v[:])
+
+	// Unlock the mutex, allowing other callers to proceed.
+	d.vMu.Unlock()
+
+	// Key rotation logic: atomically update the usage counter and, if the output threshold is
+	// exceeded, trigger asynchronous rekeying in a background goroutine. Only one goroutine
+	// may perform rekeying at a time.
 	if d.config.EnableKeyRotation {
 		atomic.AddUint64(&d.usage, uint64(len(b)))
 		if atomic.LoadUint64(&d.usage) >= d.config.MaxBytesPerKey {
@@ -336,218 +400,261 @@ func (d *drbg) Read(b []byte) (int, error) {
 			}
 		}
 	}
-	return len(b), nil
+
+	return n, nil
 }
 
-// fillBlocks fills the byte slice `b` with pseudo-random data generated
-// by the DRBG (Deterministic Random Bit Generator) instance.
+// fillBlocks fills the byte slice `b` with cryptographically secure, deterministic random data
+// generated from the provided DRBG state and a local working counter.
 //
-// This function uses the DRBG’s internal counter (`d.v`), incremented for each block,
-// and encrypted via the configured block cipher to generate deterministic output.
-// The method supports two output strategies depending on configuration:
-//
-// 1. If d.config.UseZeroBuffer is true:
-//   - An internal zero buffer (`d.zero`) is used as the temporary destination for block encryption.
-//   - It is resized if needed to match the length of `b`.
-//   - The encrypted blocks are then copied from `d.zero` into `b`.
-//
-// 2. If UseZeroBuffer is false (fast path):
-//   - The encrypted blocks are written directly into `b`.
-//   - For any remaining bytes that do not fill a full 16-byte block,
-//     encryption is performed into a temporary stack buffer (`tmp`) and the result is copied into `b`.
+// This method implements the core NIST SP 800-90A AES-CTR-DRBG output logic. It is **concurrency safe**
+// as it operates only on immutable state and caller-provided (local) counter. No DRBG struct fields are mutated.
 //
 // Parameters:
-//   - b []byte: the output buffer to be filled with generated data.
+//   - b   []byte:        Output buffer to be filled with random bytes. Must be at least 1 byte in length.
+//   - st  *state:    Immutable snapshot of the DRBG key, block cipher, and initial counter (V).
+//   - v   *[16]byte:     Local counter value (typically copied from DRBG.v). Advanced in place for each block.
 //
 // Behavior:
-//   - Each 16-byte block is generated by incrementing `d.v` and encrypting it.
-//   - No allocations occur unless the zero buffer needs to grow.
-//   - The function ensures correct handling of non-multiple-of-16 lengths.
-func (d *drbg) fillBlocks(b []byte) {
+//   - Processes output in 16-byte (AES block size) chunks for maximal efficiency.
+//   - For each block, increments the counter, encrypts it, and writes the result to output.
+//   - Supports two strategies:
+//   - UseZeroBuffer: Encrypted blocks are staged in a reusable buffer before being copied out (reducing allocations).
+//   - Fast path: Output is written directly into the caller's buffer except for a possible tail partial block,
+//     which uses a temporary [16]byte buffer.
+//
+// Returns:
+//   - None. The output is written directly to the supplied buffer `b`, and the local counter `v` is incremented
+//     in place for each block produced.
+//
+// Security:
+//   - Ensures every 16-byte block is generated with a unique counter value per NIST recommendations.
+//   - Never mutates DRBG fields or internal state directly.
+//
+// Panics:
+//   - Never panics under normal operation. Will panic only if AES block size invariants are violated
+//     (should not be possible with validated configuration).
+func (d *drbg) fillBlocks(b []byte, st *state, v *[16]byte) {
+	// Return immediately if the buffer is empty, as required by the io.Reader contract.
 	n := len(b)
 	if n == 0 {
 		return
 	}
 
+	// Buffered output mode: stage keystream in reusable buffer to minimize allocations.
 	if d.config.UseZeroBuffer {
-		// Ensure the internal zero buffer is large enough for the requested output.
+		// Ensure the zero buffer is large enough; allocate if needed.
 		if cap(d.zero) < n {
 			d.zero = make([]byte, n)
 		}
-		d.zero = d.zero[:n]
+		d.zero = d.zero[:n] // Resize without reallocating if possible.
 
 		offset := 0
-		for n > 0 {
+		remaining := n
+		for remaining > 0 {
+			// Determine block size for this iteration (full or final partial block).
 			blockSize := 16
-			if n < 16 {
-				blockSize = n // Last partial block
+			if remaining < 16 {
+				blockSize = remaining
 			}
-			d.incV()                                                          // Increment the internal counter
-			d.block.Encrypt(d.zero[offset:offset+blockSize], d.v[:])          // Encrypt the counter into the zero buffer
-			copy(b[offset:offset+blockSize], d.zero[offset:offset+blockSize]) // Copy into the output buffer
+
+			// Advance the counter as required by CTR mode (one block per keystream segment).
+			incV(v)
+
+			// Encrypt the incremented counter; write keystream into zero buffer.
+			st.block.Encrypt(d.zero[offset:offset+blockSize], v[:])
+
+			// Copy encrypted keystream to caller's buffer.
+			copy(b[offset:offset+blockSize], d.zero[offset:offset+blockSize])
 			offset += blockSize
-			n -= blockSize
+			remaining -= blockSize
 		}
 		return
 	}
 
-	// Fast path: direct write for full blocks, then use stack buffer for any final partial block.
+	// Fast path: direct write to output buffer, except for a final partial block.
 	offset := 0
-	for ; offset+16 <= len(b); offset += 16 {
-		d.incV()
-		d.block.Encrypt(b[offset:offset+16], d.v[:])
+	for ; offset+16 <= n; offset += 16 {
+		incV(v)
+		st.block.Encrypt(b[offset:offset+16], v[:])
 	}
-	if tail := len(b) - offset; tail > 0 {
+
+	// Handle remaining tail (if output is not a multiple of 16 bytes).
+	if tail := n - offset; tail > 0 {
 		var tmp [16]byte
-		d.incV()
-		d.block.Encrypt(tmp[:], d.v[:])
+		incV(v)
+		st.block.Encrypt(tmp[:], v[:])
 		copy(b[offset:], tmp[:tail])
 	}
 }
 
 // newDRBG creates and returns a new, fully initialized deterministic random bit generator (DRBG) instance.
 //
-// The DRBG is seeded with fresh entropy from the operating system (via crypto/rand), using a
-// combination of a random key and initial counter (V). Optionally, personalization data may
-// be XORed into the seed for domain separation. If either entropy acquisition or AES cipher
-// construction fails, an error is returned. This function never panics.
+// This function constructs a FIPS 140-2 aligned AES-CTR-DRBG instance, securely seeded from operating system entropy.
+// Initialization steps are as follows:
+//  1. Acquire a seed consisting of (key size + 16) bytes of cryptographically strong random data.
+//  2. Optionally XOR in a personalization string for domain separation, as required by SP 800-90A.
+//  3. Derive the AES key and initial counter (V) from the seed.
+//  4. Construct the AES block cipher with the derived key, and fail if the cipher cannot be created.
+//  5. Optionally allocate a reusable zero buffer if requested in configuration.
+//  6. Store the resulting cryptographic state atomically and initialize the working counter (v) from this state.
+//
+// If entropy acquisition or cipher construction fails, an error is returned and the DRBG is not created.
 //
 // Parameters:
-//   - cfg: Pointer to the DRBG configuration to use for initialization. Must be non-nil.
+//   - cfg: *Config — pointer to the DRBG configuration (must be non-nil)
 //
 // Returns:
-//   - *drbg: A new DRBG instance ready for use.
-//   - error: If seeding or cipher construction fails, a non-nil error is returned.
+//   - *drbg: newly initialized DRBG instance, ready for use
+//   - error: non-nil if any initialization step fails (entropy, cipher, or config error)
 func newDRBG(cfg *Config) (*drbg, error) {
-	// Calculate the required seed length: key size + 16 bytes for the initial counter (V).
 	seedLen := cfg.KeySize + 16
 
-	// Allocate a seed buffer of the required size.
+	// Allocate a buffer for the full seed: key + 128-bit counter.
 	seed := make([]byte, seedLen)
 
-	// Read the required amount of entropy from the OS cryptographically secure RNG.
+	// Read entropy from the operating system. Fail if not available.
 	if _, err := io.ReadFull(rand.Reader, seed); err != nil {
-		// If entropy acquisition fails, return an error (never panic).
 		return nil, err
 	}
 
-	// If personalization data is provided, XOR it into the seed for domain separation.
+	// XOR in personalization string (if any) for domain separation.
 	if cfg.Personalization != nil {
 		for i := range cfg.Personalization {
 			seed[i%len(seed)] ^= cfg.Personalization[i]
 		}
 	}
 
-	// Prepare the AES key as a 32-byte array (only the first KeySize bytes are used).
+	// Derive the AES key and the initial counter (V) from the seed.
 	var key [32]byte
 	copy(key[:], seed[:cfg.KeySize])
-
-	// Prepare the 16-byte counter (V) from the remainder of the seed buffer.
 	var v [16]byte
 	copy(v[:], seed[cfg.KeySize:])
 
-	// Create the AES cipher using the derived key. Only the relevant key size is used (AES-128/192/256).
+	// Construct the AES block cipher using the derived key.
 	block, err := aes.NewCipher(key[:cfg.KeySize])
 	if err != nil {
 		return nil, err
 	}
 
-	// zero buffer allocation for UseZeroBuffer mode
+	// Optionally preallocate the zero buffer for buffer-reuse mode.
 	var zero []byte
 	if cfg.UseZeroBuffer && cfg.DefaultBufferSize > 0 {
 		zero = make([]byte, cfg.DefaultBufferSize)
 	}
 
-	// Return a new DRBG instance with the configured key, counter, cipher, and reset usage counters.
-	return &drbg{
+	// Store the immutable cryptographic state atomically.
+	st := &state{
+		block: block,
+		key:   key,
+		v:     v,
+	}
+	d := &drbg{
 		config:   cfg,
-		block:    block,
-		key:      key,
-		v:        v,
+		zero:     zero,
 		usage:    0,
 		rekeying: 0,
-		zero:     zero,
-	}, nil
+	}
+	d.state.Store(st)
+
+	// Initialize the working counter (v) from the state, guaranteeing unique output on first use.
+	copy(d.v[:], v[:])
+
+	return d, nil
 }
 
-// asyncRekey performs an asynchronous, non-blocking reseed of the DRBG key/counter state.
+// asyncRekey performs an asynchronous, non-blocking reseed and key rotation for the DRBG instance.
 //
-// This function is invoked in a background goroutine when the total output bytes exceed the configured MaxBytesPerKey threshold.
-// It will retry reseeding and rekeying up to MaxRekeyAttempts, with exponential backoff between attempts (bounded by MaxRekeyBackoff).
-// On successful reseed, the internal AES key, counter, and block cipher are replaced atomically and usage is reset to zero.
-// If all attempts fail, the DRBG instance continues operating with its existing cryptographic state.
-// The function always clears the rekeying flag before returning, guaranteeing safe concurrency semantics.
+// This function is launched in a background goroutine when the generated output exceeds the configured threshold
+// (MaxBytesPerKey). It attempts to generate new entropy, derive a new key and counter, and atomically install a
+// new DRBG state. The working counter (v) is reset to the new initial value under lock. If all attempts to reseed
+// fail, the existing cryptographic state is left unchanged, and the generator continues operating.
+//
+// Steps:
+//  1. Attempt up to MaxRekeyAttempts reseed/rotate cycles, with exponential backoff (bounded by MaxRekeyBackoff).
+//  2. For each attempt:
+//     - Acquire a fresh random seed and optionally apply personalization.
+//     - Derive a new key and counter (V), and construct a new AES cipher.
+//     - On success, atomically store the new state, reset the usage counter, and set the working counter (v).
+//  3. Always clear the rekeying flag before returning (even on panic or error), so future rekeys can proceed.
+//
+// Parameters: None (method receiver only).
 func (d *drbg) asyncRekey() {
-	// Always clear the rekeying flag when this goroutine exits,
-	// regardless of whether the rekey was successful or not.
+	// Always clear the rekeying flag on exit.
 	defer atomic.StoreUint32(&d.rekeying, 0)
 
-	// Initialize the base and maximum backoff durations for retries.
 	base := d.config.RekeyBackoff
 	maxBackoff := d.config.MaxRekeyBackoff
 	if maxBackoff == 0 {
-		maxBackoff = defaultMaxBackoff // Fallback to library default if not set.
+		maxBackoff = defaultMaxBackoff
 	}
 
 	// Attempt to reseed and rekey up to MaxRekeyAttempts times.
 	for i := 0; i < d.config.MaxRekeyAttempts; i++ {
-		// Step 1: Obtain fresh entropy for the new key and counter.
-		seedLen := d.config.KeySize + 16 // Key size plus 128-bit counter.
+		// Obtain new entropy for key and counter (V).
+		seedLen := d.config.KeySize + 16 // Key size plus 128-bit counter
 		seed := make([]byte, seedLen)
 		if _, err := io.ReadFull(rand.Reader, seed); err == nil {
-			// Step 2: Apply personalization string, if set, by XORing into the seed.
+			// Apply personalization string, if set, by XORing into the seed.
 			if d.config.Personalization != nil {
-				for i := range d.config.Personalization {
-					seed[i%len(seed)] ^= d.config.Personalization[i]
+				for j := range d.config.Personalization {
+					seed[j%len(seed)] ^= d.config.Personalization[j]
 				}
 			}
 
-			// Step 3: Construct the new AES key and counter from the seed buffer.
+			// Construct the new AES key and counter (V) from the seed buffer.
 			var key [32]byte
 			copy(key[:], seed[:d.config.KeySize])
 			var v [16]byte
 			copy(v[:], seed[d.config.KeySize:])
-
-			// Step 4: Attempt to construct a new AES block cipher with the key.
 			block, err := aes.NewCipher(key[:d.config.KeySize])
 			if err == nil {
-				// Step 5: If successful, update internal state atomically and reset usage.
-				d.key = key
-				d.v = v
-				d.block = block
+				// Store new cryptographic state atomically.
+				newState := &state{
+					block: block,
+					key:   key,
+					v:     v,
+				}
+				d.state.Store(newState)
 				atomic.StoreUint64(&d.usage, 0)
+
+				// Reset the working counter (v) under mutex lock to ensure no overlap.
+				d.vMu.Lock()
+				copy(d.v[:], v[:])
+				d.vMu.Unlock()
 				return // Rekey complete.
 			}
+
 			// (If cipher construction fails, fall through and retry after backoff.)
 		}
 
-		// Step 6: Wait with exponential backoff before retrying.
+		// Wait with exponential backoff before retrying.
 		time.Sleep(base)
 		base *= 2
 		if base > maxBackoff {
 			base = maxBackoff
 		}
 	}
-
-	// If all retries failed, the DRBG continues using its prior key and counter.
+	// If all retries fail, generator continues with prior state.
 }
 
 // incV increments the DRBG counter (V) in big-endian order, rolling over as needed.
 //
-// This operation is critical for advancing the AES-CTR-DRBG internal state. The counter (V)
-// is treated as a 128-bit unsigned integer stored in big-endian format. Each call increments
-// the counter by one, wrapping as appropriate (per NIST SP 800-90A section on counter mode).
-// This ensures every block of output is unique for a given key.
+// The counter (V) is treated as a 128-bit unsigned integer in big-endian representation.
+// Each call increments the counter by one, wrapping as appropriate. This function
+// is used for advancing the DRBG keystream per SP 800-90A section on counter mode.
+// Not concurrency safe; caller must synchronize if used from multiple goroutines.
 //
-// Not concurrency safe. This method is always called within a single goroutine per DRBG instance.
-func (d *drbg) incV() {
-	// Start from the least significant byte (rightmost, index 15).
+// Parameters:
+//   - v: pointer to a 16-byte array ([16]byte), representing the current counter value.
+//
+// Returns: None (modifies v in place).
+func incV(v *[16]byte) {
+	// Start from the least significant byte (rightmost, index 15), incrementing with carry.
 	for i := 15; i >= 0; i-- {
-		d.v[i]++
-		// If increment did not overflow this byte (i.e., it is not zero),
-		// no further carry is needed, so we can exit the loop early.
-		if d.v[i] != 0 {
-			break
+		v[i]++
+		if v[i] != 0 {
+			break // No further carry needed; stop.
 		}
 	}
 }

--- a/x/crypto/ctrdrbg/aes_ctr_drbg_bench_test.go
+++ b/x/crypto/ctrdrbg/aes_ctr_drbg_bench_test.go
@@ -16,7 +16,7 @@ func (r *reader) syncPoolGetPut() {
 	r.pools[0].Put(dr)
 }
 
-func BenchmarkDRBG_Concurrent_SyncPool_Baseline(b *testing.B) {
+func BenchmarkDRBG_SyncPool_Baseline_Concurrent(b *testing.B) {
 	rdr, _ := NewReader()
 	goroutineCounts := []int{2, 4, 8, 16, 32, 64, 128}
 	if r, ok := rdr.(*reader); ok {
@@ -36,10 +36,9 @@ func BenchmarkDRBG_Concurrent_SyncPool_Baseline(b *testing.B) {
 	}
 }
 
-func BenchmarkDRBG_ReadSerial(b *testing.B) {
-	bufferSizes := []int{8, 16, 21, 32, 64, 100, 256, 512, 1000, 4096, 16384}
+func BenchmarkDRBG_Read_Serial(b *testing.B) {
+	bufferSizes := []int{16, 32, 64, 256, 512, 4096, 16384}
 	for _, size := range bufferSizes {
-		size := size
 		b.Run(fmt.Sprintf("Serial_Read_%dBytes", size), func(b *testing.B) {
 			buffer := make([]byte, size)
 			b.ReportAllocs()
@@ -54,12 +53,11 @@ func BenchmarkDRBG_ReadSerial(b *testing.B) {
 	}
 }
 
-func BenchmarkDRBG_ReadConcurrent(b *testing.B) {
-	bufferSizes := []int{16, 21, 32, 64, 100, 256, 512, 1000, 4096, 16384}
+func BenchmarkDRBG_Read_Concurrent(b *testing.B) {
+	bufferSizes := []int{16, 32, 64, 256, 512, 4096, 16384}
 	goroutineCounts := []int{2, 4, 8, 16, 32, 64, 128}
 	for _, size := range bufferSizes {
 		for _, gc := range goroutineCounts {
-			size, gc := size, gc
 			b.Run(fmt.Sprintf("Concurrent_Read_%dBytes_%dGoroutines", size, gc), func(b *testing.B) {
 				buffer := make([]byte, size)
 				b.SetParallelism(gc)
@@ -78,10 +76,9 @@ func BenchmarkDRBG_ReadConcurrent(b *testing.B) {
 	}
 }
 
-func BenchmarkDRBG_ReadSequentialLargeSizes(b *testing.B) {
-	largeBufferSizes := []int{4096, 10000, 16384, 65536, 1048576}
+func BenchmarkDRBG_Read_LargeSizes_Sequential(b *testing.B) {
+	largeBufferSizes := []int{4096, 16384, 65536, 1048576}
 	for _, size := range largeBufferSizes {
-		size := size
 		b.Run(fmt.Sprintf("Serial_Read_Large_%dBytes", size), func(b *testing.B) {
 			buffer := make([]byte, size)
 			b.ReportAllocs()
@@ -96,12 +93,11 @@ func BenchmarkDRBG_ReadSequentialLargeSizes(b *testing.B) {
 	}
 }
 
-func BenchmarkDRBG_ReadConcurrentLargeSizes(b *testing.B) {
-	largeBufferSizes := []int{4096, 10000, 16384, 65536, 1048576}
+func BenchmarkDRBG_Read_LargeSizes_Concurrent(b *testing.B) {
+	largeBufferSizes := []int{4096, 16384, 65536, 1048576}
 	goroutineCounts := []int{2, 4, 8, 16, 32, 64, 128}
 	for _, size := range largeBufferSizes {
 		for _, gc := range goroutineCounts {
-			size, gc := size, gc
 			b.Run(fmt.Sprintf("Concurrent_Read_Large_%dBytes_%dGoroutines", size, gc), func(b *testing.B) {
 				buffer := make([]byte, size)
 				b.SetParallelism(gc)
@@ -120,12 +116,11 @@ func BenchmarkDRBG_ReadConcurrentLargeSizes(b *testing.B) {
 	}
 }
 
-func BenchmarkDRBG_ReadVariableSizes(b *testing.B) {
-	variableBufferSizes := []int{8, 16, 21, 24, 32, 48, 64, 128, 256, 512, 1024, 2048, 4096}
+func BenchmarkDRBG_Read_VariableSizes(b *testing.B) {
+	variableBufferSizes := []int{16, 32, 64, 128, 256, 512, 1024, 2048, 4096}
 	for _, size := range variableBufferSizes {
-		size := size
 		b.Run(fmt.Sprintf("Serial_Read_Variable_%dBytes", size), func(b *testing.B) {
-			buffer := make([]byte, size)
+			buffer := make([]byte, size) // Allocate once
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -138,14 +133,13 @@ func BenchmarkDRBG_ReadVariableSizes(b *testing.B) {
 	}
 }
 
-func BenchmarkDRBG_ReadConcurrentVariableSizes(b *testing.B) {
-	variableBufferSizes := []int{8, 16, 21, 24, 32, 48, 64, 128, 256, 512, 1024, 2048, 4096}
+func BenchmarkDRBG_Read_VariableSizes_Concurrent(b *testing.B) {
+	variableBufferSizes := []int{16, 32, 64, 128, 256, 512, 1024, 2048, 4096}
 	goroutineCounts := []int{2, 4, 8, 16, 32, 64, 128}
 	for _, size := range variableBufferSizes {
 		for _, gc := range goroutineCounts {
-			size, gc := size, gc
 			b.Run(fmt.Sprintf("Concurrent_Read_Variable_%dBytes_%dGoroutines", size, gc), func(b *testing.B) {
-				buffer := make([]byte, size)
+				buffer := make([]byte, size) // Allocate once per benchmark run
 				b.SetParallelism(gc)
 				b.ReportAllocs()
 				b.ResetTimer()
@@ -162,13 +156,12 @@ func BenchmarkDRBG_ReadConcurrentVariableSizes(b *testing.B) {
 	}
 }
 
-func BenchmarkDRBG_ReadExtremeSizes(b *testing.B) {
+func BenchmarkDRBG_Read_ExtremeSizes(b *testing.B) {
 	extremeBufferSizes := []int{10485760, 52428800, 104857600} // 10MB, 50MB, 100MB
 	for _, size := range extremeBufferSizes {
-		size := size
 		// Serial
 		b.Run(fmt.Sprintf("Serial_Read_Extreme_%dBytes", size), func(b *testing.B) {
-			buffer := make([]byte, size)
+			buffer := make([]byte, size) // Allocate once
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -181,9 +174,8 @@ func BenchmarkDRBG_ReadExtremeSizes(b *testing.B) {
 		// Concurrent
 		goroutineCounts := []int{2, 4, 8, 16, 32, 64, 128}
 		for _, gc := range goroutineCounts {
-			gc := gc
 			b.Run(fmt.Sprintf("Concurrent_Read_Extreme_%dBytes_%dGoroutines", size, gc), func(b *testing.B) {
-				buffer := make([]byte, size)
+				buffer := make([]byte, size) // Allocate once per benchmark
 				b.SetParallelism(gc)
 				b.ReportAllocs()
 				b.ResetTimer()

--- a/x/crypto/ctrdrbg/aes_ctr_drbg_test.go
+++ b/x/crypto/ctrdrbg/aes_ctr_drbg_test.go
@@ -11,13 +11,16 @@ import (
 	"bytes"
 	"io"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-// Test_CTRDRBG_Read validates that a single call to Read fills the buffer with nonzero, random data.
+// Test_CTRDRBG_Read verifies that a single Read operation from a new DRBG instance
+// produces a buffer filled with nonzero, apparently random data. The test ensures
+// the DRBG is correctly seeded and generating cryptographically strong output on first use.
 func Test_CTRDRBG_Read(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
@@ -40,7 +43,8 @@ func Test_CTRDRBG_Read(t *testing.T) {
 	is.False(allZeros, "Buffer should not be all zeros")
 }
 
-// Test_CTRDRBG_ReadZeroBytes ensures that reading into a zero-length slice is a no-op.
+// Test_CTRDRBG_ReadZeroBytes checks that reading into a zero-length buffer
+// is a no-op and returns immediately, as required by the io.Reader contract.
 func Test_CTRDRBG_ReadZeroBytes(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
@@ -54,7 +58,8 @@ func Test_CTRDRBG_ReadZeroBytes(t *testing.T) {
 	is.Equal(0, n)
 }
 
-// Test_CTRDRBG_ReadMultipleTimes checks that consecutive Read calls yield different results.
+// Test_CTRDRBG_ReadMultipleTimes validates that consecutive Read calls from a DRBG
+// instance yield different outputs, ensuring the internal counter advances and no state is reused.
 func Test_CTRDRBG_ReadMultipleTimes(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
@@ -75,7 +80,9 @@ func Test_CTRDRBG_ReadMultipleTimes(t *testing.T) {
 	is.False(bytes.Equal(buf1, buf2), "Consecutive reads should differ")
 }
 
-// Test_CTRDRBG_ReadWithDifferentBufferSizes ensures correct output across a range of buffer sizes.
+// Test_CTRDRBG_ReadWithDifferentBufferSizes runs Read on a variety of buffer sizes (1–2KiB).
+// It ensures the returned buffer is always filled, and that the DRBG supports
+// all size requests without error or truncation.
 func Test_CTRDRBG_ReadWithDifferentBufferSizes(t *testing.T) {
 	t.Parallel()
 
@@ -106,7 +113,9 @@ func Test_CTRDRBG_ReadWithDifferentBufferSizes(t *testing.T) {
 	}
 }
 
-// Test_CTRDRBG_Concurrency verifies thread safety under heavy concurrency.
+// Test_CTRDRBG_Concurrency verifies that the DRBG is safe under heavy concurrency
+// by launching 100 goroutines, each reading a buffer in parallel. The test asserts
+// all reads succeed and at least two buffers differ, confirming thread safety and uniqueness.
 func Test_CTRDRBG_Concurrency(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
@@ -153,7 +162,9 @@ outer:
 	is.True(unique, "At least two buffers should differ")
 }
 
-// Test_CTRDRBG_Stream tests reading a large (1 MiB) buffer with io.ReadFull.
+// Test_CTRDRBG_Stream validates that reading a large (1 MiB) buffer using io.ReadFull
+// from the DRBG fills the entire buffer with nonzero, random data, ensuring correct
+// handling of large sequential requests.
 func Test_CTRDRBG_Stream(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
@@ -177,7 +188,8 @@ func Test_CTRDRBG_Stream(t *testing.T) {
 	is.False(allZeros, "Stream buffer should not be all zeros")
 }
 
-// Test_CTRDRBG_ReadAll validates that very large requests succeed and return random data.
+// Test_CTRDRBG_ReadAll checks that very large reads (10 KiB) succeed and the buffer
+// is filled with unique, nonzero data. This protects against length or edge-case errors.
 func Test_CTRDRBG_ReadAll(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
@@ -200,7 +212,9 @@ func Test_CTRDRBG_ReadAll(t *testing.T) {
 	is.False(allZeros, "ReadAll buffer should not be all zeros")
 }
 
-// Test_CTRDRBG_ReadConsistency checks that multiple reads are unique and filled.
+// Test_CTRDRBG_ReadConsistency performs 50 sequential reads from the same DRBG instance,
+// storing the output from each. It verifies every buffer is nonzero and ensures that
+// at least two reads differ, confirming uniqueness and liveness across multiple calls.
 func Test_CTRDRBG_ReadConsistency(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
@@ -242,7 +256,9 @@ outer:
 	is.True(unique, "At least two buffers should differ")
 }
 
-// Test_CTRDRBG_AsyncRekey validates that async rekeying occurs when MaxBytesPerKey is exceeded.
+// Test_CTRDRBG_AsyncRekey validates the asynchronous key rotation mechanism of the DRBG.
+// It configures a small MaxBytesPerKey to trigger a rekey, reads enough data to exceed the
+// threshold, then waits and verifies that the internal AES block is replaced and usage is reset.
 func Test_CTRDRBG_AsyncRekey(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
@@ -258,9 +274,11 @@ func Test_CTRDRBG_AsyncRekey(t *testing.T) {
 	d, err := newDRBG(&cfg)
 	is.NoError(err)
 
-	initialBlock := d.block
+	// Get a snapshot of the initial state pointer (or block pointer)
+	initialState := d.state.Load()
+	initialBlock := initialState.block
 
-	buf := make([]byte, 128) // Exceeds MaxBytesPerKey
+	buf := make([]byte, 128) // Exceeds MaxBytesPerKey, triggers rekey
 	_, err = d.Read(buf)
 	is.NoError(err)
 
@@ -272,7 +290,9 @@ func Test_CTRDRBG_AsyncRekey(t *testing.T) {
 	for {
 		select {
 		case <-tick.C:
-			if d.block != initialBlock && d.usage == 0 {
+			currState := d.state.Load()
+			// Compare block pointers (address equality) to detect a swap
+			if currState.block != initialBlock && atomic.LoadUint64(&d.usage) == 0 {
 				return // success
 			}
 		case <-wait.C:
@@ -281,8 +301,9 @@ func Test_CTRDRBG_AsyncRekey(t *testing.T) {
 	}
 }
 
-// Test_CTRDRBG_Personalization_Changes_Stream verifies that two DRBGs constructed with
-// different personalization parameters yield distinct output streams.
+// Test_CTRDRBG_Personalization_Changes_Stream ensures that two DRBG instances constructed
+// with different personalization parameters yield distinct output streams. The test asserts
+// that the personalization string directly impacts the stream as required by NIST SP 800-90A.
 func Test_CTRDRBG_Personalization_Changes_Stream(t *testing.T) {
 	t.Parallel()
 	is := assert.New(t)
@@ -369,4 +390,179 @@ func Test_CTRDRBG_Read_Shards(t *testing.T) {
 			t.Logf("Selected shard: %d (shardCount=%d)", used, tc.shardCount)
 		})
 	}
+}
+
+// TestDRBG_FillBlocks_ZeroAlloc_Functional verifies that drbg.fillBlocks produces
+// unique, non-zero cryptographically random output without any heap allocations.
+//
+// The test ensures:
+//   - The output buffer is filled with non-zero data (not all zeros).
+//   - Output changes across invocations (counter increments, no repeats).
+//   - No heap allocations occur per call, asserting high performance for this core routine.
+//
+// This is required for both performance-critical use and compliance with strict allocation budgets.
+//
+// It is a functional AND allocation test for fillBlocks, and should remain passing as the code evolves.
+func Test_DRBG_FillBlocks_ZeroAlloc(t *testing.T) {
+	cfg := DefaultConfig()
+	d, _ := newDRBG(&cfg)
+	var v [16]byte
+	buf := make([]byte, KeySize256)
+
+	st := d.state.Load()
+
+	// Warmup and baseline output
+	d.fillBlocks(buf, st, &v)
+	baseline := make([]byte, len(buf))
+	copy(baseline, buf)
+
+	allocs := testing.AllocsPerRun(10000, func() {
+		// Fill should mutate buffer and advance counter
+		d.fillBlocks(buf, st, &v)
+	})
+	if allocs != 0 {
+		t.Fatalf("unexpected allocations in fillBlocks: %v", allocs)
+	}
+	// Functional: Check that the buffer is not all zero
+	allZero := true
+	for _, b := range buf {
+		if b != 0 {
+			allZero = false
+			break
+		}
+	}
+	if allZero {
+		t.Fatal("fillBlocks wrote only zeros")
+	}
+	// Functional: Output must differ from baseline (counter advanced)
+	if string(baseline) == string(buf) {
+		t.Fatal("fillBlocks output did not change across calls (counter not advancing?)")
+	}
+}
+
+// TestDRBG_Read_Functional_Allow1Alloc verifies that drbg.Read produces non-zero,
+// unique cryptographic output, and allocates at most once per call.
+//
+// The test ensures:
+//   - The buffer is always filled with non-zero, apparently random data.
+//   - Output changes across subsequent reads (counter is advancing).
+//   - Heap allocations are ≤ 1 per call (ideally 0, but up to 1 is accepted to allow sync.Pool/runtime bookkeeping).
+//
+// This protects against accidental regression in allocation patterns or cryptographic soundness.
+func Test_DRBG_Read_OneAlloc(t *testing.T) {
+	cfg := DefaultConfig()
+	d, _ := newDRBG(&cfg)
+	buf := make([]byte, 32)
+
+	// Warm up, baseline
+	d.Read(buf)
+	baseline := make([]byte, len(buf))
+	copy(baseline, buf)
+
+	allocs := testing.AllocsPerRun(10000, func() {
+		d.Read(buf)
+	})
+	if allocs > 1 {
+		t.Fatalf("unexpected allocations: %v (expected ≤ 1)", allocs)
+	}
+	// Buffer filled?
+	allZero := true
+	for _, b := range buf {
+		if b != 0 {
+			allZero = false
+			break
+		}
+	}
+	if allZero {
+		t.Fatal("Read wrote only zeros")
+	}
+	// Output differs from baseline?
+	if string(baseline) == string(buf) {
+		t.Fatal("Read output did not change across calls (counter not advancing?)")
+	}
+}
+
+func Test_DRBG_Reader_Config(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	want := Config{
+		KeySize:           KeySize256,
+		MaxBytesPerKey:    1024 * 1024,
+		MaxInitRetries:    5,
+		MaxRekeyAttempts:  7,
+		MaxRekeyBackoff:   100 * time.Millisecond,
+		RekeyBackoff:      10 * time.Millisecond,
+		EnableKeyRotation: true,
+		Personalization:   []byte("reader-domain"),
+		UseZeroBuffer:     true,
+		DefaultBufferSize: 128,
+		Shards:            3,
+	}
+
+	rdr, err := NewReader(
+		WithKeySize(want.KeySize),
+		WithMaxBytesPerKey(want.MaxBytesPerKey),
+		WithMaxInitRetries(want.MaxInitRetries),
+		WithMaxRekeyAttempts(want.MaxRekeyAttempts),
+		WithMaxRekeyBackoff(want.MaxRekeyBackoff),
+		WithRekeyBackoff(want.RekeyBackoff),
+		WithEnableKeyRotation(want.EnableKeyRotation),
+		WithPersonalization(want.Personalization),
+		WithUseZeroBuffer(want.UseZeroBuffer),
+		WithDefaultBufferSize(want.DefaultBufferSize),
+		WithShards(want.Shards),
+	)
+	is.NoError(err)
+
+	got := rdr.Config()
+	is.Equal(want.KeySize, got.KeySize)
+	is.Equal(want.MaxBytesPerKey, got.MaxBytesPerKey)
+	is.Equal(want.MaxInitRetries, got.MaxInitRetries)
+	is.Equal(want.MaxRekeyAttempts, got.MaxRekeyAttempts)
+	is.Equal(want.MaxRekeyBackoff, got.MaxRekeyBackoff)
+	is.Equal(want.RekeyBackoff, got.RekeyBackoff)
+	is.Equal(want.EnableKeyRotation, got.EnableKeyRotation)
+	is.True(bytes.Equal(got.Personalization, want.Personalization), "Personalization does not match")
+	is.Equal(want.UseZeroBuffer, got.UseZeroBuffer)
+	is.Equal(want.DefaultBufferSize, got.DefaultBufferSize)
+	is.Equal(want.Shards, got.Shards)
+}
+
+// TestDRBG_CounterOverflow Simulate the 128-bit counter rolling over (set `d.v` to `[0xff ... 0xff]`, read one block)
+// and ensure it wraps correctly per spec. While extremely unlikely in practice, it’s a security-critical edge case.
+func Test_DRBG_CounterOverflow(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	cfg := DefaultConfig()
+	d, err := newDRBG(&cfg)
+	is.NoError(err)
+
+	// Set the DRBG's working counter to all 0xff (max 128-bit value).
+	for i := 0; i < len(d.v); i++ {
+		d.v[i] = 0xff
+	}
+
+	// Prepare output buffer (block size).
+	blockSize := 16 // AES block size
+	buf := make([]byte, blockSize)
+
+	// Read a block -- should increment counter and wrap it to zero.
+	_, err = d.Read(buf)
+	is.NoError(err)
+
+	// After increment, counter should be zero
+	expected := make([]byte, 16)
+	is.Equal(expected, d.v[:], "Counter should wrap to zero after overflow")
+
+	// Optionally, check that output is nonzero
+	allZeros := true
+	for _, b := range buf {
+		if b != 0 {
+			allZeros = false
+			break
+		}
+	}
+	is.False(allZeros, "Output block should not be all zeros")
 }

--- a/x/crypto/ctrdrbg/config_test.go
+++ b/x/crypto/ctrdrbg/config_test.go
@@ -18,13 +18,13 @@ func TestConfig_DefaultConfig(t *testing.T) {
 	is := assert.New(t)
 
 	cfg := DefaultConfig()
-	is.Equal(32, cfg.KeySize, "KeySize should default to 32 (AES-256)")
+	is.Equal(KeySize256, cfg.KeySize, "KeySize should default to 32 (AES-256)")
 	is.Equal(uint64(1<<30), cfg.MaxBytesPerKey, "MaxBytesPerKey should default to 1GiB")
 	is.Equal(3, cfg.MaxInitRetries, "MaxInitRetries should default to 3")
 	is.Equal(5, cfg.MaxRekeyAttempts, "MaxRekeyAttempts should default to 5")
 	is.Equal(2*time.Second, cfg.MaxRekeyBackoff, "MaxRekeyBackoff should default to 2s")
 	is.Equal(100*time.Millisecond, cfg.RekeyBackoff, "RekeyBackoff should default to 100ms")
-	is.True(cfg.EnableKeyRotation, "EnableKeyRotation should default to true")
+	is.False(cfg.EnableKeyRotation, "EnableKeyRotation should default to false")
 	is.Nil(cfg.Personalization, "Personalization should default to nil")
 }
 
@@ -34,8 +34,8 @@ func TestConfig_WithKeySize(t *testing.T) {
 	is := assert.New(t)
 
 	cfg := DefaultConfig()
-	WithKeySize(16)(&cfg)
-	is.Equal(16, cfg.KeySize, "WithKeySize should override KeySize")
+	WithKeySize(KeySize128)(&cfg)
+	is.Equal(KeySize128, cfg.KeySize, "WithKeySize should override KeySize")
 }
 
 // TestConfig_WithMaxBytesPerKey verifies that WithMaxBytesPerKey correctly overrides the MaxBytesPerKey field.
@@ -150,7 +150,7 @@ func TestConfig_CombinedOptions(t *testing.T) {
 
 	cfg := DefaultConfig()
 	opts := []Option{
-		WithKeySize(24),
+		WithKeySize(KeySize192),
 		WithMaxBytesPerKey(1024),
 		WithMaxInitRetries(2),
 		WithMaxRekeyAttempts(8),
@@ -162,7 +162,7 @@ func TestConfig_CombinedOptions(t *testing.T) {
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-	is.Equal(24, cfg.KeySize)
+	is.Equal(KeySize192, cfg.KeySize)
 	is.Equal(uint64(1024), cfg.MaxBytesPerKey)
 	is.Equal(2, cfg.MaxInitRetries)
 	is.Equal(8, cfg.MaxRekeyAttempts)

--- a/x/crypto/prng/README.md
+++ b/x/crypto/prng/README.md
@@ -19,6 +19,7 @@ optimized performance.
     * See the benchmark results [here](#uuid-generation).
 * **Efficient Resource Management:** Uses a `sync.Pool` to manage PRNG instances, reducing the overhead on `crypto/rand.Reader`. 
 * **Extensible API:** Allows users to create and manage custom PRNG instances via `NewReader`.
+- **UUID Generation Source:** Can be used as the `io.Reader` source for UUID generation with the [`google/uuid`](https://pkg.go.dev/github.com/google/uuid) package and similar libraries, providing cryptographically secure, deterministic UUIDs using AES-CTR-DRBG.
 
 ---
 
@@ -90,13 +91,7 @@ func main() {
 
 ### Raw Random Byte Generation
 
-Performance Benchmarks for various read sizes using the `prng.Reader`.
-
-* Throughput: ~3.77 `ns/op`
-* Memory Usage: 0 `B/op`
-* Allocations: 0 `allocs/op`
-
-These benchmarks demonstrate the package's focus on minimizing latency, memory usage, and allocation overhead, making it suitable for high-performance applications.
+These `prng.Reader` benchmarks demonstrate the package's focus on minimizing latency, memory usage, and allocation overhead, making it suitable for high-performance applications.
 
 <details>
   <summary>Expand to see results</summary>

--- a/x/crypto/prng/config.go
+++ b/x/crypto/prng/config.go
@@ -118,7 +118,7 @@ func DefaultConfig() Config {
 		EnableKeyRotation: false,
 		DefaultBufferSize: defaultBufferSize,
 		// Ref: Use of GOMAXPROCS is fine for now: https://github.com/golang/go/issues/73193
-		Shards: 1, //runtime.GOMAXPROCS(0),
+		Shards: runtime.GOMAXPROCS(0),
 	}
 }
 
@@ -195,13 +195,10 @@ func WithDefaultBufferSize(n int) Option {
 // under high concurrency, but can increase overhead on most systems.
 //
 // Note: If n <= 0, the number of shards defaults to runtime.GOMAXPROCS(0),
-// which is useful in containerized or CPU-constrained environments.
+// which is useful in containerized environments.
 // See: https://github.com/golang/go/issues/73193
 func WithShards(n int) Option {
 	return func(cfg *Config) {
-		if n <= 0 {
-			n = runtime.GOMAXPROCS(0)
-		}
 		cfg.Shards = n
 	}
 }

--- a/x/crypto/prng/prng_test.go
+++ b/x/crypto/prng/prng_test.go
@@ -402,3 +402,40 @@ func Test_PRNG_Read_Shards(t *testing.T) {
 		})
 	}
 }
+
+func Test_PRNG_Reader_Config(t *testing.T) {
+	t.Parallel()
+	is := assert.New(t)
+
+	// Custom, non-default config to verify values round-trip
+	want := Config{
+		MaxBytesPerKey:    42,
+		MaxInitRetries:    7,
+		MaxRekeyAttempts:  8,
+		MaxRekeyBackoff:   5 * time.Second,
+		RekeyBackoff:      1 * time.Second,
+		EnableKeyRotation: true,
+		UseZeroBuffer:     true,
+		DefaultBufferSize: 128,
+		Shards:            4,
+	}
+
+	// Construct via functional options
+	r, err := NewReader(
+		WithMaxBytesPerKey(want.MaxBytesPerKey),
+		WithMaxInitRetries(want.MaxInitRetries),
+		WithMaxRekeyAttempts(want.MaxRekeyAttempts),
+		WithMaxRekeyBackoff(want.MaxRekeyBackoff),
+		WithRekeyBackoff(want.RekeyBackoff),
+		WithEnableKeyRotation(want.EnableKeyRotation),
+		WithZeroBuffer(want.UseZeroBuffer),
+		WithDefaultBufferSize(want.DefaultBufferSize),
+		WithShards(want.Shards),
+	)
+	is.NoError(err)
+
+	got := r.Config()
+
+	// All fields must match (deep comparison)
+	is.Equal(want, got, "Config() should return the config passed to NewReader")
+}


### PR DESCRIPTION
- **defect**: Ensure unique cryptographic stream per `ctrdrbg.Reader` by persisting and synchronizing counter state across all Read operations (#63)
- **feature**: Add `Config()` method to `prng` and ctrdrbg implementations to retrieve generator configuration.
- **debt**: Update documentation for consistency between prng and ctrdrbg, and clarify [FIPS-140](../FIPS-140.md) and [NIST SP 800-90A AES-CTR-DRBG](https://csrc.nist.gov/publications/detail/sp/800-90a/rev-1/final) usage and compliance.