### PR TITLE
risk: Buffer capacity check

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 Six After, Inc.
+# Copyright (c) 2024-2026 Six After, Inc.
 #
 # This source code is licensed under the Apache 2.0 License found in the
 # LICENSE file in the root directory of this source tree.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 Six After, Inc.
+# Copyright (c) 2024-2026 Six After, Inc.
 #
 # This source code is licensed under the Apache 2.0 License found in the
 # LICENSE file in the root directory of this source tree.

--- a/CHANGELOG/CHANGELOG-1.x.md
+++ b/CHANGELOG/CHANGELOG-1.x.md
@@ -19,6 +19,22 @@ Date format: `YYYY-MM-DD`
 
 ---
 
+## [1.61.0] - 2026-01-19
+
+### Added
+### Changed
+- **debt:** Updated [README](../README.md) to reflect recommended usage patterns.
+- **debt:** Minor comment and documentation improvements.
+- **debt:** Updated copyright to reflect date range through present year.
+
+### Deprecated
+### Removed
+### Fixed
+### Security
+- **risk:** Buffer capacity validation now checks `cap()` instead of `len()` to prevent out-of-bounds writes with caller-supplied buffers.
+
+---
+
 ## [1.60.0] - 2026-01-16
 
 ### Added
@@ -1103,7 +1119,8 @@ Date format: `YYYY-MM-DD`
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/sixafter/nanoid/compare/v1.60.0...HEAD
+[Unreleased]: https://github.com/sixafter/nanoid/compare/v1.61.0...HEAD
+[1.61.0]: https://github.com/sixafter/nanoid/compare/v1.60.0...v1.61.0
 [1.60.0]: https://github.com/sixafter/nanoid/compare/v1.59.0...v1.60.0
 [1.59.0]: https://github.com/sixafter/nanoid/compare/v1.58.0...v1.59.0
 [1.58.0]: https://github.com/sixafter/nanoid/compare/v1.57.0...v1.58.0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 Six After, Inc.
+# Copyright (c) 2024-2026 Six After, Inc.
 #
 # This source code is licensed under the Apache 2.0 License found in the
 # LICENSE file in the root directory of this source tree.

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ Please see the [nanoid-cli](https://github.com/sixafter/nanoid-cli) for a comman
 To verify the integrity of the release, you can use Cosign to check the signature and checksums. Follow these steps:
 
 ```sh
-# Fetch the latest release tag from GitHub API (e.g., "v1.60.0")
+# Fetch the latest release tag from GitHub API (e.g., "v1.61.0")
 TAG=$(curl -s https://api.github.com/repos/sixafter/nanoid/releases/latest | jq -r .tag_name)
 
-# Remove leading "v" for filenames (e.g., "v1.60.0" -> "1.60.0")
+# Remove leading "v" for filenames (e.g., "v1.61.0" -> "1.61.0")
 VERSION=${TAG#v}
 
 # ---------------------------------------------------------------------
@@ -248,7 +248,7 @@ func main() {
 	}
 
 	// Generate a Nano ID using the custom generator
-	id, err := gen.NewWithLength(10)
+	id, err := gen.New() // or gen.NewWithLength(10)
 	if err != nil {
 		fmt.Println("Error generating Nano ID:", err)
 		return
@@ -324,21 +324,9 @@ This project integrates a cryptographically secure, high-performance random numb
 
 For implementation details, benchmark results, and usage, see the CSPRNG [README](https://github.com/sixafter/prng-chacha).
 
-### Buffer Pooling with `sync.Pool`
+## Execute Benchmarks
 
-The nanoid generator utilizes `sync.Pool` to manage byte slice buffers efficiently. This approach minimizes memory allocations and enhances performance, especially in high-concurrency scenarios.
-
-How It Works:
-* Storing Pointers: `sync.Pool` stores pointers to `[]byte` (or `[]rune` if Unicode) slices (`*[]byte`) instead of the slices themselves. This avoids unnecessary allocations and aligns with best practices for using `sync.Pool`.
-* Zeroing Buffers: Before returning buffers to the pool, they are zeroed out to prevent data leaks.
-
-### Struct Optimization
-
-The `generator` struct is optimized for memory alignment and size by ordering from largest to smallest to minimize padding and optimize memory usage.
-
-## Execute Benchmarks:
-
-Run the benchmarks using the `go test` command with the `bench` make target:
+Run the benchmarks using the  `bench` make target:
 
 ```shell
 make bench
@@ -538,12 +526,11 @@ Nano ID generates unique identifiers based on the following:
 
 1. Alphabet Lengths:
    * At Least Two Characters: The custom alphabet must contain at least two unique characters. An alphabet with fewer than two characters cannot produce IDs with sufficient variability or randomness.
-   * Maximum Length 256 Characters: The implementation utilizes a rune-based approach, where each character in the alphabet is represented by a single rune. This allows for a broad range of unique characters, accommodating alphabets with up to 256 distinct runes. Attempting to use an alphabet with more than 256 runes will result in an error. 
+   * Maximum Length 256 Characters: The implementation uses a rune-based approach, where a single rune represents each character in the alphabet. This allows for a broad range of unique characters, accommodating alphabets with up to 256 distinct runes. Attempting to use an alphabet with more than 256 runes will result in an error. 
 2. Uniqueness of Characters:
    * All Characters Must Be Unique. Duplicate characters in the alphabet can introduce biases in ID generation and compromise the randomness and uniqueness of the IDs. The generator enforces uniqueness by checking for duplicates during initialization. If duplicates are detected, it will return an `ErrDuplicateCharacters` error. 
 3. Character Encoding:
    * Support for ASCII and Unicode: The generator accepts alphabets containing Unicode characters, allowing you to include a wide range of symbols, emojis, or characters from various languages.
-
 
 ## Determining Collisions
 

--- a/config.go
+++ b/config.go
@@ -306,7 +306,7 @@ func buildRuntimeConfig(opts *ConfigOptions) (*runtimeConfig, error) {
 		return nil, ErrInvalidAlphabet
 	}
 
-	// Check if the alphabet is valid UTF-8
+	// Validate UTF-8 encoding to detect length miscalculation and inconsistent string operations.
 	if !utf8.ValidString(opts.Alphabet) {
 		return nil, ErrNonUTF8Alphabet
 	}
@@ -374,7 +374,8 @@ func buildRuntimeConfig(opts *ConfigOptions) (*runtimeConfig, error) {
 	//adjustedBitsNeeded := bitsNeeded + uint(math.Log2(float64(opts.LengthHint)))
 
 	// Determine the number of bytes required to store 'bitsNeeded' bits, rounding up to the nearest byte.
-	bytesNeeded := (bitsNeeded + 7) / 8
+	const bitsPerByte = 8
+	bytesNeeded := (bitsNeeded + bitsPerByte - 1) / bitsPerByte
 
 	// Check if the alphabet length is a power of two, allowing optimization of modulus operations using bitwise AND.
 	// This optimization improves performance during random index generation.

--- a/errors.go
+++ b/errors.go
@@ -10,6 +10,15 @@ import (
 )
 
 var (
+	// ErrAlphabetTooLong is returned when the provided alphabet exceeds 256 characters.
+	ErrAlphabetTooLong = errors.New("alphabet length exceeds 256")
+
+	// ErrAlphabetTooShort is returned when the provided alphabet has fewer than 2 characters.
+	ErrAlphabetTooShort = errors.New("alphabet length is less than 2")
+
+	// ErrInsufficientBufferCapacity is returned when the provided buffer's capacity is too small for the requested operation.
+	ErrInsufficientBufferCapacity = errors.New("buffer capacity insufficient")
+
 	// ErrDuplicateCharacters is returned when the provided alphabet contains duplicate characters.
 	ErrDuplicateCharacters = errors.New("duplicate characters in alphabet")
 
@@ -17,25 +26,19 @@ var (
 	// an operation, such as generating a unique ID, has been exceeded.
 	ErrExceededMaxAttempts = errors.New("exceeded maximum attempts")
 
-	// ErrInvalidLength is returned when a specified length value for an operation is invalid.
-	ErrInvalidLength = errors.New("invalid length")
-
 	// ErrInvalidAlphabet is returned when the provided alphabet for generating IDs is invalid.
 	ErrInvalidAlphabet = errors.New("invalid alphabet")
 
-	// ErrNonUTF8Alphabet is returned when the provided alphabet contains non-UTF-8 characters.
-	ErrNonUTF8Alphabet = errors.New("alphabet contains invalid UTF-8 characters")
+	// ErrInvalidLength is returned when a specified length value for an operation is invalid.
+	ErrInvalidLength = errors.New("invalid length")
 
-	// ErrAlphabetTooShort is returned when the provided alphabet has fewer than 2 characters.
-	ErrAlphabetTooShort = errors.New("alphabet length is less than 2")
-
-	// ErrAlphabetTooLong is returned when the provided alphabet exceeds 256 characters.
-	ErrAlphabetTooLong = errors.New("alphabet length exceeds 256")
+	// ErrNilPointer is returned when a nil pointer is passed to a function that does not accept nil pointers.
+	ErrNilPointer = errors.New("nil pointer")
 
 	// ErrNilRandReader is returned when the random number generator (rand.Reader) is nil,
 	// preventing the generation of random values.
 	ErrNilRandReader = errors.New("nil random reader")
 
-	// ErrNilPointer is returned when a nil pointer is passed to a function that does not accept nil pointers.
-	ErrNilPointer = errors.New("nil pointer")
+	// ErrNonUTF8Alphabet is returned when the provided alphabet contains non-UTF-8 characters.
+	ErrNonUTF8Alphabet = errors.New("alphabet contains invalid UTF-8 characters")
 )

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sixafter/aes-ctr-drbg v1.15.0
 	github.com/sixafter/prng-chacha v1.13.0
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/exp v0.0.0-20250813145105-42675adae3e6
+	golang.org/x/exp v0.0.0-20260112195511-716be5621a96
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
 golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
-golang.org/x/exp v0.0.0-20250813145105-42675adae3e6 h1:SbTAbRFnd5kjQXbczszQ0hdk3ctwYf3qBNH9jIsGclE=
-golang.org/x/exp v0.0.0-20250813145105-42675adae3e6/go.mod h1:4QTo5u+SEIbbKW1RacMZq1YEfOBqeXa19JeshGi+zc4=
+golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=
+golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
 golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
 golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/nanoid.go
+++ b/nanoid.go
@@ -22,6 +22,7 @@ var (
 	// RandReader is the default random number generator used for generating IDs.
 	RandReader = prng.Reader
 
+	// Ensure that generator implements the Interface.
 	_ Interface = (*generator)(nil)
 )
 
@@ -105,8 +106,8 @@ type Interface interface {
 	// This can be useful for directly obtaining random bytes or integrating with other components that consume random data.
 	//
 	// Usage:
-	//   buffer := make([]byte, 21)
-	//   n, err := generator.Read(buffer)
+	//   buf := make([]byte, 21)
+	//   n, err := generator.Read(buf)
 	//   if err != nil {
 	//       // handle error
 	//   }
@@ -121,8 +122,6 @@ type generator struct {
 	config      *runtimeConfig
 	entropyPool *sync.Pool
 	idPool      *sync.Pool
-	Interface
-	Configuration
 }
 
 // New generates a new Nano ID using the default length specified by `DefaultLength`.
@@ -482,44 +481,43 @@ func (g *generator) Read(p []byte) (int, error) {
 //	}
 //	fmt.Println(string(buf))
 func (g *generator) newASCII(length int, idBuffer []byte) error {
-	// --- Parameter validation: Ensure the output buffer is large enough. ---
-	if len(idBuffer) < length {
-		return fmt.Errorf("buffer too small")
+	if cap(idBuffer) < length {
+		return fmt.Errorf("%w: need %d, got %d", ErrInsufficientBufferCapacity, length, cap(idBuffer))
 	}
 
-	// --- Acquire a buffer for entropy from the pool for efficient random data handling. ---
+	// Acquire a buffer for entropy from the pool for efficient random data handling.
 	randomBytesPtr := g.entropyPool.Get().(*[]byte)
 	randomBytes := *randomBytesPtr
 	bufferLen := len(randomBytes)
 	defer g.entropyPool.Put(randomBytesPtr) // Always return the buffer to the pool.
 
-	// --- Initialize internal state for NanoID generation. ---
+	// Initialize internal state for NanoID generation.
 	cursor := 0                                   // Tracks how many characters have been written.
 	maxAttempts := length * maxAttemptsMultiplier // Upper bound to prevent infinite loops.
 	mask := g.config.mask                         // Bitmask for index truncation.
 	bytesNeeded := g.config.bytesNeeded           // Bytes required for each index sample.
 	isPowerOfTwo := g.config.isPowerOfTwo         // Optimization for binary-friendly alphabets.
 
-	// --- Main generation loop: Fill idBuffer with valid random characters. ---
+	// Main generation loop: Fill idBuffer with valid random characters.
 	for attempts := 0; cursor < length && attempts < maxAttempts; attempts++ {
-		// --- Determine how many random bytes are needed for this iteration. ---
+		// Determine how many random bytes are needed for this iteration.
 		neededBytes := (length - cursor) * int(bytesNeeded)
 		if neededBytes > bufferLen {
 			neededBytes = bufferLen
 		}
 
-		// --- Refill the entropy buffer with secure random bytes. ---
+		// Refill the entropy buffer with secure random bytes.
 		if _, err := g.config.randReader.Read(randomBytes[:neededBytes]); err != nil {
 			// Propagate any error from the random reader.
 			return err
 		}
 
-		// --- Use each segment of random bytes to select characters from the alphabet. ---
+		// Use each segment of random bytes to select characters from the alphabet.
 		for i := 0; i < neededBytes && cursor < length; i += int(bytesNeeded) {
 			rnd := g.processRandomBytes(randomBytes, i) // Extract an integer sample.
 			rnd &= mask                                 // Mask for non-power-of-two alphabet sizes.
 
-			// --- If the random index is valid, select the character and write to output. ---
+			// If the random index is valid, select the character and write to output.
 			if isPowerOfTwo || int(rnd) < int(g.config.alphabetLen) {
 				idBuffer[cursor] = g.config.byteAlphabet[rnd]
 				cursor++
@@ -527,7 +525,7 @@ func (g *generator) newASCII(length int, idBuffer []byte) error {
 		}
 	}
 
-	// --- If unable to generate a full ID within the allowed attempts, return an error. ---
+	// If unable to generate a full ID within the allowed attempts, return an error.
 	if cursor < length {
 		return ErrExceededMaxAttempts
 	}
@@ -557,44 +555,43 @@ func (g *generator) newASCII(length int, idBuffer []byte) error {
 //	}
 //	fmt.Println(string(buf))
 func (g *generator) newUnicode(length int, idBuffer []rune) error {
-	// --- Parameter validation: Ensure output buffer is large enough. ---
-	if len(idBuffer) < length {
-		return fmt.Errorf("buffer too small")
+	if cap(idBuffer) < length {
+		return fmt.Errorf("%w: need %d, got %d", ErrInsufficientBufferCapacity, length, cap(idBuffer))
 	}
 
-	// --- Acquire a buffer for entropy from the pool for efficient random data handling. ---
+	// Acquire a buffer for entropy from the pool for efficient random data handling.
 	randomBytesPtr := g.entropyPool.Get().(*[]byte)
 	randomBytes := *randomBytesPtr
 	bufferLen := len(randomBytes)
 	defer g.entropyPool.Put(randomBytesPtr) // Always return buffer to the pool.
 
-	// --- Initialize internal state for NanoID generation. ---
+	// Initialize internal state for NanoID generation.
 	cursor := 0                                   // Tracks how many runes have been written.
 	maxAttempts := length * maxAttemptsMultiplier // Upper bound to prevent infinite loops.
 	mask := g.config.mask                         // Bitmask for index truncation.
 	bytesNeeded := g.config.bytesNeeded           // Bytes required for each index sample.
 	isPowerOfTwo := g.config.isPowerOfTwo         // Optimization for binary-friendly alphabets.
 
-	// --- Main generation loop: Fill idBuffer with valid random runes. ---
+	// Main generation loop: Fill idBuffer with valid random runes.
 	for attempts := 0; cursor < length && attempts < maxAttempts; attempts++ {
-		// --- Determine how many random bytes are needed for this iteration. ---
+		// Determine how many random bytes are needed for this iteration.
 		neededBytes := (length - cursor) * int(bytesNeeded)
 		if neededBytes > bufferLen {
 			neededBytes = bufferLen
 		}
 
-		// --- Refill the entropy buffer with secure random bytes. ---
+		// Refill the entropy buffer with secure random bytes.
 		if _, err := g.config.randReader.Read(randomBytes[:neededBytes]); err != nil {
 			// Propagate any error from the random reader.
 			return err
 		}
 
-		// --- Use each segment of random bytes to select runes from the alphabet. ---
+		// Use each segment of random bytes to select runes from the alphabet.
 		for i := 0; i < neededBytes && cursor < length; i += int(bytesNeeded) {
 			rnd := g.processRandomBytes(randomBytes, i) // Extract an integer sample.
 			rnd &= mask                                 // Mask for non-power-of-two alphabet sizes.
 
-			// --- If the random index is valid, select the rune and write to output. ---
+			// If the random index is valid, select the rune and write to output.
 			if isPowerOfTwo || int(rnd) < int(g.config.alphabetLen) {
 				idBuffer[cursor] = g.config.runeAlphabet[rnd]
 				cursor++
@@ -602,7 +599,7 @@ func (g *generator) newUnicode(length int, idBuffer []rune) error {
 		}
 	}
 
-	// --- If unable to generate a full ID within the allowed attempts, return an error. ---
+	// If unable to generate a full ID within the allowed attempts, return an error.
 	if cursor < length {
 		return ErrExceededMaxAttempts
 	}

--- a/nanoid_benchmark_test.go
+++ b/nanoid_benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 Six After, Inc.
+// Copyright (c) 2024-2026 Six After, Inc.
 //
 // This source code is licensed under the Apache 2.0 License found in the
 // LICENSE file in the root directory of this source tree.

--- a/scripts/go-deps.sh
+++ b/scripts/go-deps.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024-2025 Six After, Inc.
+# Copyright (c) 2024-2026 Six After, Inc.
 #
 # This source code is licensed under the Apache 2.0 License found in the
 # LICENSE file in the root directory of this source tree.

--- a/scripts/go-install.sh
+++ b/scripts/go-install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024-2025 Six After, Inc.
+# Copyright (c) 2024-2026 Six After, Inc.
 #
 # This source code is licensed under the Apache 2.0 License found in the
 # LICENSE file in the root directory of this source tree.

--- a/scripts/os-type.sh
+++ b/scripts/os-type.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024-2025 Six After, Inc.
+# Copyright (c) 2024-2026 Six After, Inc.
 #
 # This source code is licensed under the Apache 2.0 License found in the
 # LICENSE file in the root directory of this source tree.

--- a/scripts/verify-mod.sh
+++ b/scripts/verify-mod.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024-2025 Six After, Inc.
+# Copyright (c) 2024-2026 Six After, Inc.
 #
 # This source code is licensed under the Apache 2.0 License found in the
 # LICENSE file in the root directory of this source tree.

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024-2025 Six After, Inc.
+# Copyright (c) 2024-2026 Six After, Inc.
 #
 # This source code is licensed under the Apache 2.0 License found in the
 # LICENSE file in the root directory of this source tree.

--- a/scripts/verify-sig.sh
+++ b/scripts/verify-sig.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2024-2025 Six After, Inc.
+# Copyright (c) 2024-2026 Six After, Inc.
 #
 # This source code is licensed under the Apache 2.0 License found in the
 # LICENSE file in the root directory of this source tree.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -18,7 +18,7 @@ github.com/stretchr/testify/assert/yaml
 ## explicit; go 1.24.0
 golang.org/x/crypto/chacha20
 golang.org/x/crypto/internal/alias
-# golang.org/x/exp v0.0.0-20250813145105-42675adae3e6
+# golang.org/x/exp v0.0.0-20260112195511-716be5621a96
 ## explicit; go 1.24.0
 golang.org/x/exp/constraints
 # golang.org/x/sys v0.40.0


### PR DESCRIPTION
This PR addresses the following.

- **debt:** Updated `README.md` to reflect recommended usage patterns.
- **debt:** Minor comment and documentation improvements.
- **debt:** Updated copyright to reflect date range through present year.
- **risk:** Buffer capacity validation now checks `cap()` instead of `len()` to prevent out-of-bounds writes with caller-supplied buffers.
